### PR TITLE
AbstractVectorOfArray broadcast overload

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -167,10 +167,7 @@ end
 
 @inline function Base.copy(bc::Broadcast.Broadcasted{VectorOfArrayStyle{Style}}) where Style
     N = narrays(bc)
-    @show "here"
     x = unpack_voa(bc, 1)
-    @show x
-    @show copy(x)
     VectorOfArray(map(1:N) do i
         copy(unpack_voa(bc, i))
     end)

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -158,7 +158,7 @@ VectorOfArrayStyle(::Any, ::Any) = VectorOfArrayStyle()
 #    VectorOfArrayStyle(Broadcast.BroadcastStyle(AStyle(), BStyle()))
 #end
 Broadcast.BroadcastStyle(::VectorOfArrayStyle, ::Broadcast.BroadcastStyle) = VectorOfArrayStyle()
-#Broadcast.BroadcastStyle(::VectorOfArrayStyle, ::Broadcast.DefaultArrayStyle{N}) where N = Broadcast.DefaultArrayStyle{N}()
+Broadcast.BroadcastStyle(::VectorOfArrayStyle, ::Broadcast.DefaultArrayStyle{N}) where N = Broadcast.DefaultArrayStyle{N}()
 
 function Broadcast.BroadcastStyle(::Type{<:AbstractVectorOfArray{T,S}}) where {T, S}
     VectorOfArrayStyle()

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -161,7 +161,7 @@ end
 Broadcast.BroadcastStyle(::VectorOfArrayStyle{Style}, ::Broadcast.DefaultArrayStyle{0}) where Style<:Broadcast.BroadcastStyle = VectorOfArrayStyle{Style}()
 Broadcast.BroadcastStyle(::VectorOfArrayStyle, ::Broadcast.DefaultArrayStyle{N}) where N = Broadcast.DefaultArrayStyle{N}()
 
-function Broadcast.BroadcastStyle(::Type{AbstractVectorOfArray{T,S}}) where {T, N}
+function Broadcast.BroadcastStyle(::Type{AbstractVectorOfArray{T,S}}) where {T, S}
     VectorOfArrayStyle(Broadcast.result_style(Broadcast.BroadcastStyle(T)))
 end
 

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -1,4 +1,4 @@
-using RecursiveArrayTools
+using RecursiveArrayTools, Test
 
 # Example Problem
 recs = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -86,3 +86,5 @@ v = VectorOfArray([zeros(20), zeros(10,10), zeros(3,3,3)])
 v[CartesianIndex((2, 3, 2, 3))] = 1
 @test v[CartesianIndex((2, 3, 2, 3))] == 1
 @test v.u[3][2, 3, 2] == 1
+
+v .* v

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -96,4 +96,4 @@ w = v .* v
 @test w[3] == v[3] .* v[3]
 x = copy(v)
 x .= v .* v
-@test all(x .== w)
+@test x.u == w.u

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -87,4 +87,13 @@ v[CartesianIndex((2, 3, 2, 3))] = 1
 @test v[CartesianIndex((2, 3, 2, 3))] == 1
 @test v.u[3][2, 3, 2] == 1
 
-v .* v
+v = VectorOfArray([rand(20), rand(10,10), rand(3,3,3)])
+w = v .* v
+@test w isa VectorOfArray
+@test w[1] isa Vector
+@test w[1] == v[1] .* v[1]
+@test w[2] == v[2] .* v[2]
+@test w[3] == v[3] .* v[3]
+x = copy(v)
+x .= v .* v
+@test all(x .== w)


### PR DESCRIPTION
Relies on Julia's v1.5 `@view` optimizations to be super fast, but the main reason for this is because it's more correct on ragged arrays. However, it's currently hitting a weird problem:

```julia
[ Info: Precompiling RecursiveArrayTools [731186ca-8d62-57ce-b412-fbd966d074cd]

Please submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.
Exception: EXCEPTION_ACCESS_VIOLATION at 0x6690ec5e -- jl_subtype_env at /cygdrive/d/buildbot/worker/package_win64/build/src\subtype.c:1800
in expression starting at none:0
jl_subtype_env at /cygdrive/d/buildbot/worker/package_win64/build/src\subtype.c:1800
jl_subtype at /cygdrive/d/buildbot/worker/package_win64/build/src\subtype.c:1854 [inlined]
jl_isa at /cygdrive/d/buildbot/worker/package_win64/build/src\subtype.c:2056
rewrap at .\compiler\typeutils.jl:8 [inlined]
matching_cache_argtypes at .\compiler\inferenceresult.jl:132
InferenceResult at .\compiler\inferenceresult.jl:12 [inlined]
InferenceResult at .\compiler\inferenceresult.jl:12 [inlined]
typeinf_ext at .\compiler\typeinfer.jl:572
typeinf_ext at .\compiler\typeinfer.jl:605
jfptr_typeinf_ext_1.clone_1 at C:\Users\accou\AppData\Local\Programs\Julia\Julia-1.4.1\lib\julia\sys.dll (unknown line)
jl_apply at /cygdrive/d/buildbot/worker/package_win64/build/src\julia.h:1700 [inlined]
jl_type_infer at /cygdrive/d/buildbot/worker/package_win64/build/src\gf.c:213
jl_compile_method_internal at /cygdrive/d/buildbot/worker/package_win64/build/src\gf.c:1887
_jl_invoke at /cygdrive/d/buildbot/worker/package_win64/build/src\gf.c:2153 [inlined]
jl_apply_generic at /cygdrive/d/buildbot/worker/package_win64/build/src\gf.c:2322
_reformat_bt at .\error.jl:90
#catch_stack#49 at .\error.jl:149
catch_stack at .\error.jl:144 [inlined]
catch_stack at .\error.jl:144 [inlined]
_start at .\client.jl:486
jfptr__start_2087.clone_1 at C:\Users\accou\AppData\Local\Programs\Julia\Julia-1.4.1\lib\julia\sys.dll (unknown line)
unknown function (ip: 00000000004017E1)
unknown function (ip: 0000000000401BD6)
unknown function (ip: 00000000004013DE)
unknown function (ip: 000000000040151A)
BaseThreadInitThunk at C:\WINDOWS\System32\KERNEL32.DLL (unknown line)
RtlUserThreadStart at C:\WINDOWS\SYSTEM32\ntdll.dll (unknown line)
Allocations: 5137387 (Pool: 5136723; Big: 664); GC: 3
```