### PR TITLE
Define the custom adjoint on a more general ArrayPartition constructor

### DIFF
--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -15,13 +15,14 @@ ZygoteRules.@adjoint function getindex(VA::AbstractVectorOfArray, i, j...)
   VA[i,j...],AbstractVectorOfArray_getindex_adjoint
 end
 
-ZygoteRules.@adjoint function ArrayPartition(x...)
+ZygoteRules.@adjoint function ArrayPartition(x::S, ::Type{Val{copy_x}} = Val{false}) where {S<:Tuple,copy_x}
   function ArrayPartition_adjoint(_y)
       y = Array(_y)
       starts = vcat(0,cumsum(reduce(vcat,length.(x))))
-      ntuple(i -> reshape(y[starts[i]+1:starts[i+1]],size(x[i])),length(x))
+      ntuple(i -> reshape(y[starts[i]+1:starts[i+1]], size(x[i])), length(x)), nothing
   end
-  ArrayPartition(x...),ArrayPartition_adjoint
+
+  ArrayPartition(x, Val{copy_x}), ArrayPartition_adjoint
 end
 
 ZygoteRules.@adjoint function VectorOfArray(u)


### PR DESCRIPTION
Computing the adjoint of a `SecondOrderODEProblem` requires an adjoint for this constructor because of the following line.

https://github.com/SciML/DiffEqBase.jl/blob/9f0875ad24ac9c2f5784b242eba5344807f278e7/src/problems/ode_problems.jl#L153

This PR depends on FluxML/ZygoteRules.jl#12 because of the anonymous value type argument. That was a fun one to debug :)