### PR TITLE
bump compat version bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 ArrayInterface = "2.7"
 RecipesBase = "0.7, 0.8, 1.0"
 Requires = "0.5, 1.0"
-StaticArrays = "0.10, 0.11, 0.12"
+StaticArrays = "1.0"
 ZygoteRules = "0.2"
 julia = "1.3"
 


### PR DESCRIPTION
If tests pass, there should be a new release of RecursiveArrayTools.jl since it holds back updates for NonlinearSolve.jl (https://github.com/JuliaComputing/NonlinearSolve.jl/pull/16) and DiffEqBase.jl (SciML/DiffEqBase.jl#604) which in turns hold back updates for a lot of downstream packages.

This needs a new release of OrdinaryDiffEq.jl.