### PR TITLE
Fixes #125

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -7,7 +7,7 @@ end
 ArrayPartition(x...) = ArrayPartition((x...,))
 
 function ArrayPartition(x::S, ::Type{Val{copy_x}}=Val{false}) where {S<:Tuple,copy_x}
-  T = promote_type(eltype.(x)...)
+  T = promote_type(recursive_bottom_eltype.(x)...)
   if copy_x
     return ArrayPartition{T,S}(copy.(x))
   else

--- a/test/partitions_and_static_arrays.jl
+++ b/test/partitions_and_static_arrays.jl
@@ -1,0 +1,10 @@
+using Test, RecursiveArrayTools, StaticArrays
+
+p = ArrayPartition((zeros(Float32, 2), zeros(SMatrix{2,2, Int64},2), zeros(SVector{3, Float64}, 2)))
+@test eltype(p)==Float64
+@test recursive_bottom_eltype(p)==Float64
+@test recursive_unitless_eltype(p)==Float64
+@test recursive_unitless_bottom_eltype(p)==Float64
+
+p2 = similar(p)
+@test typeof(p2)==typeof(p)


### PR DESCRIPTION
Fixed the determination of eltype of ArrayPartition in the case of complex nested arrays, such as vectors of StaticArrays, for example.

Fixes #125