### PR TITLE
fix ArrayInterface.ismutable(::ArrayPartition)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+.vscode

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -70,6 +70,11 @@ end
 # ignore dims since array partitions are vectors
 Base.ones(A::ArrayPartition, dims::NTuple{N,Int}) where {N} = ones(A)
 
+# mutable iff all components of ArrayPartition are mutable
+function ArrayInterface.ismutable(::Type{<:ArrayPartition{T,S}}) where {T,S}
+    all(ArrayInterface.ismutable, S.parameters)
+end
+
 ## vector space operations
 
 for op in (:+, :-)

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -71,8 +71,9 @@ end
 Base.ones(A::ArrayPartition, dims::NTuple{N,Int}) where {N} = ones(A)
 
 # mutable iff all components of ArrayPartition are mutable
-function ArrayInterface.ismutable(::Type{<:ArrayPartition{T,S}}) where {T,S}
-    all(ArrayInterface.ismutable, S.parameters)
+@generated function ArrayInterface.ismutable(::Type{<:ArrayPartition{T,S}}) where {T,S}
+    res = all(ArrayInterface.ismutable, S.parameters)
+    return :( $res )
 end
 
 ## vector space operations

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -1,4 +1,4 @@
-using RecursiveArrayTools, Test, Statistics
+using RecursiveArrayTools, Test, Statistics, ArrayInterface
 A = (rand(5),rand(5))
 p = ArrayPartition(A)
 @test (p.x[1][1],p.x[2][1]) == (p[1],p[6])
@@ -135,3 +135,7 @@ function foo(y, x)
 end
 foo(xcde0, xce0)
 #@test 0 == @allocated foo(xcde0, xce0)
+
+@testset "ArrayInterface.ismutable(ArrayPartition($a, $b)) == $r" for (a, b, r) in ((1,2, false), ([1], 2, false), ([1], [2], true))
+    @test ArrayInterface.ismutable(ArrayPartition(a, b)) == r
+end


### PR DESCRIPTION
A `PartitionedArray` should be considered "mutable" only, if all of its components are "mutable".
Therefore the `ArrayInterface.ismutable` has been specialized for this case.
This fixes a bug in https://github.com/SciML/OrdinaryDiffEq.jl/issues/1322

Another question is the naming `ArrayInteface.ismutable` which collides with `Base.ismutable` and returns different results.