### PR TITLE
Add more specialized functions

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -110,11 +110,16 @@ end
 
 Base.:(==)(A::ArrayPartition,B::ArrayPartition) = A.x == B.x
 
-## Functional Constructs
+## Iterable Collection Constructs
 
 Base.mapreduce(f,op,A::ArrayPartition) = mapreduce(f,op,(mapreduce(f,op,x) for x in A.x))
 Base.any(f,A::ArrayPartition) = any(f,(any(f,x) for x in A.x))
 Base.any(f::Function,A::ArrayPartition) = any(f,(any(f,x) for x in A.x))
+Base.any(A::ArrayPartition) = any(identity, A)
+Base.all(f,A::ArrayPartition) = all(f,(all(f,x) for x in A.x))
+Base.all(f::Function,A::ArrayPartition) = all(f,(all(f,x) for x in A.x))
+Base.all(A::ArrayPartition) = all(identity, A)
+
 function Base.copyto!(dest::AbstractArray,A::ArrayPartition)
     @assert length(dest) == length(A)
     cur = 1


### PR DESCRIPTION
- Adds an `any` method without predicate. Needed for efficiently calling `any` on e.g. `ArrayPartition{Float32, Tuple{CuArray{Float32, 1}, CuArray{Float32, 1}}}`
- Adds analogous `all` methods.