### PR TITLE
Allow DefaultArrayStyle to be broadcast according to normal rules

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -306,6 +306,8 @@ _npartitions(args::Tuple{}) = 0
 # drop axes because it is easier to recompute
 @inline unpack(bc::Broadcast.Broadcasted{Style}, i) where Style = Broadcast.Broadcasted(bc.f, unpack_args(i, bc.args))
 @inline unpack(bc::Broadcast.Broadcasted{ArrayPartitionStyle{Style}}, i) where Style = Broadcast.Broadcasted(bc.f, unpack_args(i, bc.args))
+@inline unpack(bc::Broadcast.Broadcasted{Style}, i) where Style <: Broadcast.DefaultArrayStyle = Broadcast.Broadcasted{Style}(bc.f, unpack_args(i, bc.args))
+@inline unpack(bc::Broadcast.Broadcasted{ArrayPartitionStyle{Style}}, i) where Style <: Broadcast.DefaultArrayStyle = Broadcast.Broadcasted{Style}(bc.f, unpack_args(i, bc.args))
 unpack(x,::Any) = x
 unpack(x::ArrayPartition, i) = x.x[i]
 

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -172,6 +172,13 @@ up = ap .+ 1
 up = 2 .* ap .+ 1
 @test typeof(ap) == typeof(up)
 
+# Test that `zeros()` does not get screwed up
+ap = ArrayPartition(zeros(),[1.0])
+up = ap .+ 1
+@test typeof(ap) == typeof(up)
+
+up = 2 .* ap .+ 1
+@test typeof(ap) == typeof(up)
 
 @testset "ArrayInterface.ismutable(ArrayPartition($a, $b)) == $r" for (a, b, r) in ((1,2, false), ([1], 2, false), ([1], [2], true))
     @test ArrayInterface.ismutable(ArrayPartition(a, b)) == r


### PR DESCRIPTION
Hot fix to #137 

The original issue lies in the way broadcasting works for `zeros()`, since `zeros().+2.0` gets turned from `Array{Float64, 0}` into `Float64`, because apparently that is how broadcasting is set up for `DefaultArrayStyle{0}` (This seems like a bug in Julia.) Before #136, this wasn't a problem for broadcasting of `ArrayPartition` as long as an `Array{Float64, 0}` was paired with another component of higher `Array` rank, e.g., `ap = ArrayPartition(zeros(),[1.0])`, since they would all be broadcast via `DefaultArrayStyle{1}` rules. So `ap+1.0` would be of the same type as `ap`. But on its own, e.g., `ap = ArrayPartition(zeros())`, then `ap + 1.0` would *not* be the same type as `ap`, since it gets broadcast as a `DefaultArrayStyle{0}`. Unfortunately, #136 exposed this issue.
  
This PR provides a more narrowly defined scope for when components of ArrayPartition will change their style in `unpack` from that of the promoted style of the overall Broadcasted wrapper of the ArrayPartition. If it is of `DefaultArrayStyle`, then it keeps the overall wrapper's style, thereby preserving the behavior before #136. But if the ArrayPartition contains a custom type with its own BroadcastStyle, then it parses the components' styles and therefore still allows specialized dispatch on `copy`.