### PR TITLE
Faster `map` over `ArrayPartition`s.

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -112,6 +112,7 @@ Base.:(==)(A::ArrayPartition,B::ArrayPartition) = A.x == B.x
 
 ## Iterable Collection Constructs
 
+Base.map(f,A::ArrayPartition) = ArrayPartition(map(x->map(f,x), A.x))
 Base.mapreduce(f,op,A::ArrayPartition) = mapreduce(f,op,(mapreduce(f,op,x) for x in A.x))
 Base.any(f,A::ArrayPartition) = any(f,(any(f,x) for x in A.x))
 Base.any(f::Function,A::ArrayPartition) = any(f,(any(f,x) for x in A.x))

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -103,6 +103,9 @@ _broadcast_wrapper(y) = _scalar_op.(y)
 # Issue #8
 # @inferred _broadcast_wrapper(x)
 
+# Testing map
+@test map(x->x^2, x) == ArrayPartition(x.x[1].^2, x.x[2].^2)
+
 #### testing copyto!
 S = [
      ((1,),(2,)) => ((1,),(2,)),


### PR DESCRIPTION
Specialized `map` method over a single `ArrayPartition` to close #140.