### PR TITLE
Make ZygoteRules for getindex use `zero`

### DIFF
--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -1,6 +1,7 @@
 ZygoteRules.@adjoint function getindex(VA::AbstractVectorOfArray, i)
   function AbstractVectorOfArray_getindex_adjoint(Δ)
-    Δ′ = [ (i == j ? Δ : zero(x)) for (x,j) in zip(VA.u, 1:length(VA))]
+    Δ′ = zero(VA)
+    Δ′[i] = Δ
     (Δ′,nothing)
   end
   VA[i],AbstractVectorOfArray_getindex_adjoint


### PR DESCRIPTION
Prelude to an actual fix for https://github.com/SciML/ModelingToolkit.jl/issues/972.  This makes the two ZygoteRules for getindex more alike, in that both now use `zero` to construct a copy of the array and then slice into it. The error message for the original problem becomes more comprehensible. 