### PR TITLE
Broaden vector eltype signature for `push!`

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -169,7 +169,7 @@ Base.copy(VA::AbstractDiffEqArray) = typeof(VA)(
   )
 Base.copy(VA::AbstractVectorOfArray) = typeof(VA)(copy(VA.u))
 Base.sizehint!(VA::AbstractVectorOfArray{T, N}, i) where {T, N} = sizehint!(VA.u, i)
-Base.push!(VA::AbstractVectorOfArray{T, N}, new_item::AbstractVector) where {T, N} = push!(VA.u, new_item)
+Base.push!(VA::AbstractVectorOfArray{T, N}, new_item::AbstractArray) where {T, N} = push!(VA.u, new_item)
 
 function Base.append!(VA::AbstractVectorOfArray{T, N}, new_item::AbstractVectorOfArray{T, N}) where {T, N}
     for item in copy(new_item)


### PR DESCRIPTION
Pushing to `AbstractVectorOfArray` is currently limited to vectors with eltype `AbstractVector`, which seems likely to have been a too-restrictive oversight. This PR broadens the accepted eltype to `AbstractArray`.