### PR TITLE
[WIP] remove un-roundtripable 2-arg `show` methods

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -244,7 +244,6 @@ Base.last(A::ArrayPartition) = last(last(A.x))
 
 ## display
 Base.summary(A::ArrayPartition) = string(typeof(A), " with arrays:")
-Base.show(io::IO,A::ArrayPartition) = map(x->Base.show(io,x),A.x)
 Base.show(io::IO, m::MIME"text/plain", A::ArrayPartition) = show(io, m, A.x)
 
 ## broadcasting

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -220,11 +220,9 @@ Base.vec(VA::AbstractVectorOfArray) = vec(convert(Array,VA)) # Allocates
 @inline Statistics.cor(VA::AbstractVectorOfArray;kwargs...) = cor(Array(VA);kwargs...)
 
 # make it show just like its data
-Base.show(io::IO, x::AbstractVectorOfArray) = Base.print_array(io, x.u)
 Base.show(io::IO, m::MIME"text/plain", x::AbstractVectorOfArray) = (println(io, summary(x), ':'); show(io, m, x.u))
 Base.summary(A::AbstractVectorOfArray) = string("VectorOfArray{",eltype(A),",",ndims(A),"}")
 
-Base.show(io::IO, x::AbstractDiffEqArray) = (print(io,"t: ");show(io, x.t);println(io);print(io,"u: ");show(io, x.u))
 Base.show(io::IO, m::MIME"text/plain", x::AbstractDiffEqArray) = (print(io,"t: ");show(io,m,x.t);println(io);print(io,"u: ");show(io,m,x.u))
 
 # plot recipes


### PR DESCRIPTION
in https://github.com/SciML/ModelingToolkit.jl/pull/1127 
I make writing Systems to file include symbolics' reserved metadata (like units, and noise).

however, the custom 2-arg pretty printing used here breaks the ability to reparse the result of `show` methods for NoiseProcesses like so `var"##sts#259"[1] = setmetadata(var"##sts#259"[1], ModelingToolkit.VariableNoiseType, t: [0] u: [0])`
where `t: [0] u: [0]` is really `WienerProcess(0, 0, 0)`

now it gets shown as `[0]` so still bad

cc @YingboMa 