### PR TITLE
Round-trip printing

### DIFF
--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -5,30 +5,32 @@ $(DocStringExtensions.README)
 module RecursiveArrayTools
 
 using DocStringExtensions
-  using Requires, RecipesBase, StaticArrays, Statistics,
-        ArrayInterface, LinearAlgebra
+using Requires, RecipesBase, StaticArrays, Statistics,
+      ArrayInterface, LinearAlgebra
 
-  import ChainRulesCore
-  import ChainRulesCore: NoTangent
-  import ZygoteRules
-  abstract type AbstractVectorOfArray{T, N, A} <: AbstractArray{T, N} end
-  abstract type AbstractDiffEqArray{T, N, A} <: AbstractVectorOfArray{T, N, A} end
+import ChainRulesCore
+import ChainRulesCore: NoTangent
+import ZygoteRules
+abstract type AbstractVectorOfArray{T, N, A} <: AbstractArray{T, N} end
+abstract type AbstractDiffEqArray{T, N, A} <: AbstractVectorOfArray{T, N, A} end
 
-  include("utils.jl")
-  include("vector_of_array.jl")
-  include("array_partition.jl")
-  include("init.jl")
-  include("zygote.jl")
+include("utils.jl")
+include("vector_of_array.jl")
+include("array_partition.jl")
+include("init.jl")
+include("zygote.jl")
 
-  export VectorOfArray, DiffEqArray, AbstractVectorOfArray, AbstractDiffEqArray,
+Base.show(io::IO, x::Union{ArrayPartition,AbstractVectorOfArray}) = invoke(show, Tuple{typeof(io), Any}, io, x)
+
+export VectorOfArray, DiffEqArray, AbstractVectorOfArray, AbstractDiffEqArray,
        AllObserved, vecarr_to_arr, vecarr_to_vectors, tuples
 
-  export recursivecopy, recursivecopy!, vecvecapply, copyat_or_push!,
-         vecvec_to_mat, recursive_one, recursive_mean, recursive_bottom_eltype,
-         recursive_unitless_bottom_eltype, recursive_unitless_eltype
+export recursivecopy, recursivecopy!, vecvecapply, copyat_or_push!,
+       vecvec_to_mat, recursive_one, recursive_mean, recursive_bottom_eltype,
+       recursive_unitless_bottom_eltype, recursive_unitless_eltype
 
 
-  export ArrayPartition
+export ArrayPartition
 
 
 end # module

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -244,7 +244,6 @@ Base.last(A::ArrayPartition) = last(last(A.x))
 
 ## display
 Base.summary(A::ArrayPartition) = string(typeof(A), " with arrays:")
-Base.show(io::IO,A::ArrayPartition) = map(x->Base.show(io,x),A.x)
 Base.show(io::IO, m::MIME"text/plain", A::ArrayPartition) = show(io, m, A.x)
 
 ## broadcasting

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -220,11 +220,9 @@ Base.vec(VA::AbstractVectorOfArray) = vec(convert(Array,VA)) # Allocates
 @inline Statistics.cor(VA::AbstractVectorOfArray;kwargs...) = cor(Array(VA);kwargs...)
 
 # make it show just like its data
-Base.show(io::IO, x::AbstractVectorOfArray) = Base.print_array(io, x.u)
 Base.show(io::IO, m::MIME"text/plain", x::AbstractVectorOfArray) = (println(io, summary(x), ':'); show(io, m, x.u))
 Base.summary(A::AbstractVectorOfArray) = string("VectorOfArray{",eltype(A),",",ndims(A),"}")
 
-Base.show(io::IO, x::AbstractDiffEqArray) = (print(io,"t: ");show(io, x.t);println(io);print(io,"u: ");show(io, x.u))
 Base.show(io::IO, m::MIME"text/plain", x::AbstractDiffEqArray) = (print(io,"t: ");show(io,m,x.t);println(io);print(io,"u: ");show(io,m,x.u))
 
 # plot recipes


### PR DESCRIPTION
Need https://github.com/SciML/ResettableStacks.jl/pull/15 and https://github.com/JuliaRandom/RandomNumbers.jl/pull/79

They are required to make the printing round-trip-able
```julia
julia> W = WienerProcess(1,2,3)
t: 1-element Vector{Int64}:
 1
u: 1-element Vector{Int64}:
 2

julia> show(W)
NoiseProcess{Int64, 1, Int64, Int64, Int64, Vector{Int64}, typeof(DiffEqNoiseProcess.WHITE_NOISE_DIST), typeof(DiffEqNoiseProcess.WHITE_NOISE_BRIDGE), false, ResettableStack{Tuple{Int64, Int64, Int64}, false}, ResettableStack{Tuple{Int64, Int64, Int64}, false}, RSWM{Float64}, Nothing, RandomNumbers.Xorshifts.Xoroshiro128Plus}(DiffEqNoiseProcess.WHITE_NOISE_DIST, DiffEqNoiseProcess.WHITE_NOISE_BRIDGE, [1], [2], [2], [3], 1, 2, 3, 1, 2, 3, 2, 3, 2, 3, ResettableStack{Tuple{Int64, Int64, Int64}, false}(Tuple{Int64, Int64, Int64}[], 0, 0), ResettableStack{Tuple{Int64, Int64, Int64}, false}(Tuple{Int64, Int64, Int64}[], 0, 0), RSWM{Float64}(1.0e-15, :RSwM3), 0, 0, true, 0, RandomNumbers.Xorshifts.Xoroshiro128Plus(0xa31c9616241b8143, 0x84824147765d2431), true, true, true, nothing)
julia> NoiseProcess{Int64, 1, Int64, Int64, Int64, Vector{Int64}, typeof(DiffEqNoiseProcess.WHITE_NOISE_DIST), typeof(DiffEqNoiseProcess.WHITE_NOISE_BRIDGE), false, ResettableStack{Tuple{Int64, Int64, Int64}, false}, ResettableStack{Tuple{Int64, Int64, Int64}, false}, RSWM{Float64}, Nothing, RandomNumbers.Xorshifts.Xoroshiro128Plus}(DiffEqNoiseProcess.WHITE_NOISE_DIST, DiffEqNoiseProcess.WHITE_NOISE_BRIDGE, [1], [2], [2], [3], 1, 2, 3, 1, 2, 3, 2, 3, 2, 3, ResettableStack{Tuple{Int64, Int64, Int64}, false}(Tuple{Int64, Int64, Int64}[], 0, 0), ResettableStack{Tuple{Int64, Int64, Int64}, false}(Tuple{Int64, Int64, Int64}[], 0, 0), RSWM{Float64}(1.0e-15, :RSwM3), 0, 0, true, 0, RandomNumbers.Xorshifts.Xoroshiro128Plus(0xa31c9616241b8143, 0x84824147765d2431), true, true, true, nothing)
t: 1-element Vector{Int64}:
 1
u: 1-element Vector{Int64}:
 2
```