### PR TITLE
Update coverage badges to the SciML organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # RecursiveArrayTools.jl
 
 [![Build Status](https://github.com/SciML/RecursiveArrayTools.jl/workflows/CI/badge.svg)](https://github.com/SciML/RecursiveArrayTools.jl/actions?query=workflow%3ACI)
-[![Coverage Status](https://coveralls.io/repos/ChrisRackauckas/RecursiveArrayTools.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/ChrisRackauckas/RecursiveArrayTools.jl?branch=master)
-[![codecov.io](http://codecov.io/github/ChrisRackauckas/RecursiveArrayTools.jl/coverage.svg?branch=master)](http://codecov.io/github/ChrisRackauckas/RecursiveArrayTools.jl?branch=master)
+[![codecov.io](http://codecov.io/github/SciML/RecursiveArrayTools.jl/coverage.svg?branch=master)](http://codecov.io/github/SciML/RecursiveArrayTools.jl?branch=master)
 
 RecursiveArrayTools.jl is a set of tools for dealing with recursive arrays like
 arrays of arrays. The current functionality includes:


### PR DESCRIPTION
It looks like only Codedov is currently active so I've dropped the Coveralls badge.