### PR TITLE
Provide base case for recursive eltype functions

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,12 +93,14 @@ recursive_one(a::T) where {T<:Number} = one(a)
 recursive_bottom_eltype(a) = a == eltype(a) ? a : recursive_bottom_eltype(eltype(a))
 
 recursive_unitless_bottom_eltype(a) = recursive_unitless_bottom_eltype(typeof(a))
+recursive_unitless_bottom_eltype(a::Type{Any}) = Any
 recursive_unitless_bottom_eltype(a::Type{T}) where T = recursive_unitless_bottom_eltype(eltype(a))
 recursive_unitless_bottom_eltype(a::Type{T}) where {T<:AbstractArray} = recursive_unitless_bottom_eltype(eltype(a))
 recursive_unitless_bottom_eltype(a::Type{T}) where {T<:Number} = eltype(a) == Number ? Float64 : typeof(one(eltype(a)))
 recursive_unitless_bottom_eltype(::Type{<:Enum{T}}) where T = T
 
 recursive_unitless_eltype(a) = recursive_unitless_eltype(eltype(a))
+recursive_unitless_eltype(a::Type{Any}) = Any
 recursive_unitless_eltype(a::Type{T}) where {T<:StaticArray} = similar_type(a,recursive_unitless_eltype(eltype(a)))
 recursive_unitless_eltype(a::Type{T}) where {T<:Array} = Array{recursive_unitless_eltype(eltype(a)),ndims(a)}
 recursive_unitless_eltype(a::Type{T}) where {T<:Number} = typeof(one(eltype(a)))


### PR DESCRIPTION
Addresses https://github.com/SciML/ModelingToolkit.jl/issues/1353
The problem in the linked issue is not solved completely since the eltype infers to `Any`, but this PR prevents the stackoverflow.