### PR TITLE
Fix unary minus for nested ArrayPartition

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -106,6 +106,10 @@ for op in (:+, :-)
     end
 end
 
+function Base.:-(A::ArrayPartition)
+    return ArrayPartition(map(-, A.x))
+end
+
 for op in (:*, :/)
     @eval function Base.$op(A::ArrayPartition, B::Number)
         ArrayPartition(map(y->Base.broadcast($op, y, B), A.x))

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -191,3 +191,9 @@ up = 2 .* ap .+ 1
 @testset "ArrayInterface.ismutable(ArrayPartition($a, $b)) == $r" for (a, b, r) in ((1,2, false), ([1], 2, false), ([1], [2], true))
     @test ArrayInterface.ismutable(ArrayPartition(a, b)) == r
 end
+
+# Test unary minus
+
+x = ArrayPartition(ArrayPartition([1, 2]), [3, 4])
+@test -x == 0-x
+@test typeof(x) === typeof(-x)


### PR DESCRIPTION
Without this custom method the inner `ArrayPartition` of a nested `ArrayPartition` is turned into a normal vector by unary minus.