### PR TITLE
Only require ArrayInterfaceCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,11 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.27.1"
+version = "2.28.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
@@ -18,7 +18,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 Adapt = "3"
-ArrayInterface = "2.7, 3.0, 4, 5"
+ArrayInterfaceCore = "0.1.1"
 ChainRulesCore = "0.10.7, 1"
 DocStringExtensions = "0.8"
 FillArrays = "0.11, 0.12, 0.13"

--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -6,7 +6,7 @@ module RecursiveArrayTools
 
 using DocStringExtensions
 using RecipesBase, StaticArrays, Statistics,
-      ArrayInterface, LinearAlgebra
+      ArrayInterfaceCore, LinearAlgebra
 
 import ChainRulesCore
 import ChainRulesCore: NoTangent

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -83,8 +83,8 @@ end
 Base.ones(A::ArrayPartition, dims::NTuple{N,Int}) where {N} = ones(A)
 
 # mutable iff all components of ArrayPartition are mutable
-@generated function ArrayInterface.ismutable(::Type{<:ArrayPartition{T,S}}) where {T,S}
-    res = all(ArrayInterface.ismutable, S.parameters)
+@generated function ArrayInterfaceCore.ismutable(::Type{<:ArrayPartition{T,S}}) where {T,S}
+    res = all(ArrayInterfaceCore.ismutable, S.parameters)
     return :( $res )
 end
 
@@ -342,7 +342,7 @@ common_number(a, b) =
 
 ## Linear Algebra
 
-ArrayInterface.zeromatrix(A::ArrayPartition) = ArrayInterface.zeromatrix(Vector(A))
+ArrayInterfaceCore.zeromatrix(A::ArrayPartition) = ArrayInterfaceCore.zeromatrix(Vector(A))
 
 LinearAlgebra.ldiv!(A::Factorization, b::ArrayPartition) = (x = ldiv!(A, Array(b)); copyto!(b, x))
 function LinearAlgebra.ldiv!(A::LU, b::ArrayPartition)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,11 +7,11 @@ function recursivecopy(a::AbstractArray{T,N}) where {T<:Number,N}
 end
 
 function recursivecopy(a::AbstractArray{T,N}) where {T<:AbstractArray,N}
-  if ArrayInterface.ismutable(a)
+  if ArrayInterfaceCore.ismutable(a)
     b = similar(a)
     map!(recursivecopy, b, a)
   else
-    ArrayInterface.restructure(a, map(recursivecopy, a))
+    ArrayInterfaceCore.restructure(a, map(recursivecopy, a))
   end
 end
 
@@ -31,7 +31,7 @@ function recursivecopy!(b::AbstractArray{T,N},a::AbstractArray{T2,N}) where {T<:
 end
 
 function recursivecopy!(b::AbstractArray{T,N},a::AbstractArray{T2,N}) where {T<:AbstractArray,T2<:AbstractArray,N}
-  if ArrayInterface.ismutable(T)
+  if ArrayInterfaceCore.ismutable(T)
     @inbounds for i in eachindex(b, a)
       recursivecopy!(b[i], a[i])
     end
@@ -108,7 +108,7 @@ end
 
 function copyat_or_push!(a::AbstractVector{T},i::Int,x,nc::Type{Val{perform_copy}}=Val{true}) where {T,perform_copy}
   @inbounds if length(a) >= i
-    if !ArrayInterface.ismutable(T) || !perform_copy
+    if !ArrayInterfaceCore.ismutable(T) || !perform_copy
       # TODO: Check for `setindex!`` if T <: StaticArray and use `copy!(b[i],a[i])`
       #       or `b[i] = a[i]`, see https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19
       a[i] = x

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -1,4 +1,4 @@
-using RecursiveArrayTools, Test, Statistics, ArrayInterface
+using RecursiveArrayTools, Test, Statistics, ArrayInterfaceCore
 A = (rand(5),rand(5))
 p = ArrayPartition(A)
 @test (p.x[1][1],p.x[2][1]) == (p[1],p[6])
@@ -188,8 +188,8 @@ up = ap .+ 1
 up = 2 .* ap .+ 1
 @test typeof(ap) == typeof(up)
 
-@testset "ArrayInterface.ismutable(ArrayPartition($a, $b)) == $r" for (a, b, r) in ((1,2, false), ([1], 2, false), ([1], [2], true))
-    @test ArrayInterface.ismutable(ArrayPartition(a, b)) == r
+@testset "ArrayInterfaceCore.ismutable(ArrayPartition($a, $b)) == $r" for (a, b, r) in ((1,2, false), ([1], 2, false), ([1], [2], true))
+    @test ArrayInterfaceCore.ismutable(ArrayPartition(a, b)) == r
 end
 
 # Test unary minus

--- a/test/upstream.jl
+++ b/test/upstream.jl
@@ -1,11 +1,11 @@
-using OrdinaryDiffEq, NLsolve, RecursiveArrayTools, Test, ArrayInterface
+using OrdinaryDiffEq, NLsolve, RecursiveArrayTools, Test, ArrayInterfaceCore
 function lorenz(du,u,p,t)
     du[1] = 10.0*(u[2]-u[1])
     du[2] = u[1]*(28.0-u[3]) - u[2]
     du[3] = u[1]*u[2] - (8/3)*u[3]
 end
 u0 = ArrayPartition([1.0,0.0],[0.0])
-@test ArrayInterface.zeromatrix(u0) isa Matrix
+@test ArrayInterfaceCore.zeromatrix(u0) isa Matrix
 tspan = (0.0,100.0)
 prob = ODEProblem(lorenz,u0,tspan)
 sol = solve(prob,Tsit5())


### PR DESCRIPTION
Before and after:

```julia
julia> @time_imports using RecursiveArrayTools
     10.7 ms    ┌ MacroTools
     19.2 ms  ┌ ZygoteRules
      2.8 ms  ┌ Compat
      1.4 ms  ┌ Requires
    123.4 ms  ┌ FillArrays
    507.7 ms  ┌ StaticArrays
     17.8 ms      ┌ Preferences
     19.6 ms    ┌ JLLWrappers
    184.0 ms  ┌ LLVMExtra_jll
      5.1 ms      ┌ CEnum
    108.6 ms    ┌ LLVM
      1.9 ms    ┌ Adapt
    804.4 ms  ┌ GPUArrays
      5.8 ms  ┌ DocStringExtensions
      1.3 ms  ┌ IfElse
     39.8 ms  ┌ RecipesBase
     40.6 ms    ┌ Static
    504.1 ms  ┌ ArrayInterface
     73.6 ms  ┌ ChainRulesCore
   2332.6 ms  RecursiveArrayTools

julia> @time_imports using RecursiveArrayTools
    10.1 ms    ┌ MacroTools
    18.7 ms  ┌ ZygoteRules
    2.6 ms  ┌ Compat
123.9 ms  ┌ FillArrays
521.7 ms  ┌ StaticArrays
    18.4 ms      ┌ Preferences
    20.2 ms    ┌ JLLWrappers
173.5 ms  ┌ LLVMExtra_jll
    4.8 ms      ┌ CEnum
103.7 ms    ┌ LLVM
    2.0 ms    ┌ Adapt
815.3 ms  ┌ GPUArrays
    5.2 ms  ┌ DocStringExtensions
    40.3 ms  ┌ RecipesBase
    2.6 ms  ┌ ArrayInterfaceCore
    56.6 ms  ┌ ChainRulesCore
1822.5 ms  RecursiveArrayTools
```