### PR TITLE
Base.length dispatch for ArrayPartition (StaticArrays)

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -504,4 +504,10 @@ function Base.convert(::Type{ArrayPartition{T,S}}, A::ArrayPartition{<:Any,<:NTu
     )
 end
             
-Base.length(::Type{<:ArrayPartition{F,T}}) where {F,T <: Tuple} = T.parameters .|> length |> sum
+@generated function Base.length(::Type{<:ArrayPartition{F,T}}) where {F,N,T <: NTuple{N,StaticArray}} 
+    sum_expr = Expr(:call, :+)
+    for param in T.parameters
+        push!(sum_expr.args, :(length($param)))
+    end
+    return sum_expr
+end

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -503,3 +503,5 @@ function Base.convert(::Type{ArrayPartition{T,S}}, A::ArrayPartition{<:Any,<:NTu
         ntuple((@inline i -> convert(S.parameters[i], A.x[i])), Val(N))
     )
 end
+            
+Base.length(::Type{<:ArrayPartition{F,T}}) where {F,T <: Tuple} = T.parameters .|> length |> sum

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -504,7 +504,7 @@ function Base.convert(::Type{ArrayPartition{T,S}}, A::ArrayPartition{<:Any,<:NTu
     )
 end
             
-@generated function Base.length(::Type{<:ArrayPartition{F,T}}) where {F,N,T <: NTuple{N,StaticArray}} 
+@generated function Base.length(::Type{<:ArrayPartition{F,T}}) where {F,N,T <: NTuple{N, StaticArraysCore.StaticArray}} 
     sum_expr = Expr(:call, :+)
     for param in T.parameters
         push!(sum_expr.args, :(length($param)))

--- a/test/partitions_and_static_arrays.jl
+++ b/test/partitions_and_static_arrays.jl
@@ -10,4 +10,4 @@ p2 = similar(p)
 @test typeof(p2)==typeof(p)
 
 p3 = ArrayPartition(SA[1.0, 2.0], MMatrix{2,2}([3.0 4.0; 3.0 5.0]))
-@test length(typeof(p3)) == 6
+@test (@inferred length(typeof(p3))) == 6

--- a/test/partitions_and_static_arrays.jl
+++ b/test/partitions_and_static_arrays.jl
@@ -8,3 +8,6 @@ p = ArrayPartition((zeros(Float32, 2), zeros(SMatrix{2,2, Int64},2), zeros(SVect
 
 p2 = similar(p)
 @test typeof(p2)==typeof(p)
+
+p3 = ArrayPartition(SA[1.0, 2.0], MMatrix{2,2}([3.0 4.0; 3.0 5.0]))
+@test length(typeof(p3)) == 6


### PR DESCRIPTION
This only works for partition elements that themselves have a length-on-type function, e.g. SVector or SMatrix.

I'm trying to use this line of code from NearestNeighbors.jl (issue on the call `length(::Type{ArrayPartition...}})`:
https://github.com/KristofferC/NearestNeighbors.jl/blob/fb84d15b96a2d7f94f691db4ff6f42e994194c93/src/tree_data.jl#L14

MWE I'm working to fix:
```julia
using Manifolds, NearestNeighbors, Distances, StaticArrays
import Manifolds: ArrayPartition

Base.@kwdef struct DistSE2 <: Distances.Metric
  M = SpecialEuclidean(2)
end 
(d::DistSE2)(p,q) = Manifolds.ManifoldsBase.distance(d.M,p,q)

pts = [ArrayPartition(SA[randn(2)...], SMatrix{2,2}([1 0; 0 1.])) for _ in 1:10]
dSE2 = DistSE2()

bt = NearestNeighbors.BallTree(pts, dSE2)

# adding this PR corrects the error
# Base.length(::Type{<:ArrayPartition{F,T}}) where {F,T <: Tuple} = T.parameters .|> length |> sum
```

-----

```julia
julia> bt = NearestNeighbors.BallTree(pts, dSE2)
ERROR: MethodError: no method matching length(::Type{ArrayPartition{Float64, Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}}})
Closest candidates are:
  length(::Union{Base.KeySet, Base.ValueIterator}) at /usr/local/share/julia-1.7.3/share/julia/base/abstractdict.jl:58
  length(::Union{DataStructures.OrderedRobinDict, DataStructures.RobinDict}) at ~/.julia/packages/DataStructures/59MD0/src/ordered_robin_dict.jl:86
  length(::Union{DataStructures.SortedDict, DataStructures.SortedMultiDict, DataStructures.SortedSet}) at ~/.julia/packages/DataStructures/59MD0/src/container_loops.jl:322
  ...
Stacktrace:
 [1] NearestNeighbors.TreeData(data::Vector{ArrayPartition{Float64, Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}}}, leafsize::Int64)
   @ NearestNeighbors ~/.julia/packages/NearestNeighbors/VZzTb/src/tree_data.jl:14
 [2] BallTree(data::Vector{ArrayPartition{Float64, Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}}}, metric::DistSE2; leafsize::Int64, reorder::Bool, storedata::Bool, reorderbuffer::Vector{ArrayPartition{Float64, Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}}})
   @ NearestNeighbors ~/.julia/packages/NearestNeighbors/VZzTb/src/ball_tree.jl:39
 [3] BallTree(data::Vector{ArrayPartition{Float64, Tuple{SVector{2, Float64}, SMatrix{2, 2, Float64, 4}}}}, metric::DistSE2)
   @ NearestNeighbors ~/.julia/packages/NearestNeighbors/VZzTb/src/ball_tree.jl:37
 [4] top-level scope
   @ REPL[11]:1
```

Currently there are further errors that I'm working separately.

----

xref: Using Manifolds.jl objects represented as `ArrayPartition`, 
- https://github.com/JuliaRobotics/ApproxManifoldProducts.jl/issues/41#issuecomment-733636425