### PR TITLE
Fix (colon,j...) indexing of ArrayPartition

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -220,6 +220,18 @@ Base.@propagate_inbounds function Base.getindex(A::ArrayPartition, i::Int, j...)
 end
 
 """
+    getindex(A::ArrayPartition, i::Colon, j...)
+
+Returns the entry at index `j...` of  every partition of `A`.
+"""
+Base.@propagate_inbounds function Base.getindex(A::ArrayPartition, i::Colon, j...)
+  @boundscheck 0 < i <= length(A.x) || throw(BoundsError(A.x, i))
+  @inbounds b = A.x[i]
+  @boundscheck checkbounds(b, j...)
+  @inbounds return b[j...]
+end
+
+"""
     getindex(A::ArrayPartition, ::Colon)
 
 Returns a vector with all elements of array partition `A`.

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -225,10 +225,7 @@ end
 Returns the entry at index `j...` of  every partition of `A`.
 """
 Base.@propagate_inbounds function Base.getindex(A::ArrayPartition, i::Colon, j...)
-  @boundscheck 0 < i <= length(A.x) || throw(BoundsError(A.x, i))
-  @inbounds b = A.x[i]
-  @boundscheck checkbounds(b, j...)
-  @inbounds return b[j...]
+    return getindex.(A.x, (j...,))
 end
 
 """

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -58,6 +58,7 @@ copyto!(p,c)
 ## inference tests
 
 x = ArrayPartition([1, 2], [3.0, 4.0])
+@test x[:,1] == (1,3.0)
 
 # similar partitions
 @inferred similar(x)


### PR DESCRIPTION
Because ArrayPartition is an AbstractVector but allows a non-square indexing scheme, this confuses the defaults and thus this requires a specialization. Fixes https://github.com/SciML/RecursiveArrayTools.jl/pull/239