### PR TITLE
Fix `recursivefill!` for `VectorOfArray{<:StaticArray}`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -86,10 +86,26 @@ function recursivefill!(b::AbstractArray{T, N},
     end
 end
 
+function recursivefill!(bs::AbstractVectorOfArray{T, N},
+                        a::T2) where {T <: StaticArraysCore.StaticArray,
+                                      T2 <: StaticArraysCore.StaticArray, N}
+    @inbounds for b in bs, i in eachindex(b)
+        b[i] = copy(a)
+    end
+end
+
 function recursivefill!(b::AbstractArray{T, N},
                         a::T2) where {T <: StaticArraysCore.SArray,
                                       T2 <: Union{Number, Bool}, N}
     @inbounds for i in eachindex(b)
+        b[i] = fill(a, typeof(b[i]))
+    end
+end
+
+function recursivefill!(bs::AbstractVectorOfArray{T, N},
+                        a::T2) where {T <: StaticArraysCore.SArray,
+                                      T2 <: Union{Number, Bool}, N}
+    @inbounds for b in bs, i in eachindex(b)
         b[i] = fill(a, typeof(b[i]))
     end
 end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -99,3 +99,21 @@ x = similar(x)
 recursivefill!(x, true)
 @test x[1] == MVector{10}(ones(10))
 @test x[2] == MVector{10}(ones(10))
+
+# Test VectorOfArray + recursivefill! + static arrays
+@testset "VectorOfArray + recursivefill! + static arrays" begin
+    Vec3 = SVector{3, Float64}
+    x = [randn(Vec3, n) for n ∈ 1:4]  # vector of vectors of static arrays
+
+    x_voa = VectorOfArray(x)
+    @test eltype(x_voa) === Vec3
+    @test first(x_voa) isa AbstractVector{Vec3}
+
+    y_voa = recursivecopy(x_voa)
+    recursivefill!(y_voa, true)
+    @test all(y_voa[n] == fill(ones(Vec3), n) for n ∈ 1:4)
+
+    y_voa = recursivecopy(x_voa)
+    recursivefill!(y_voa, ones(Vec3))
+    @test all(y_voa[n] == fill(ones(Vec3), n) for n ∈ 1:4)
+end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -103,7 +103,7 @@ recursivefill!(x, true)
 # Test VectorOfArray + recursivefill! + static arrays
 @testset "VectorOfArray + recursivefill! + static arrays" begin
     Vec3 = SVector{3, Float64}
-    x = [randn(Vec3, n) for n ∈ 1:4]  # vector of vectors of static arrays
+    x = [randn(Vec3, n) for n in 1:4]  # vector of vectors of static arrays
 
     x_voa = VectorOfArray(x)
     @test eltype(x_voa) === Vec3
@@ -111,9 +111,9 @@ recursivefill!(x, true)
 
     y_voa = recursivecopy(x_voa)
     recursivefill!(y_voa, true)
-    @test all(y_voa[n] == fill(ones(Vec3), n) for n ∈ 1:4)
+    @test all(y_voa[n] == fill(ones(Vec3), n) for n in 1:4)
 
     y_voa = recursivecopy(x_voa)
     recursivefill!(y_voa, ones(Vec3))
-    @test all(y_voa[n] == fill(ones(Vec3), n) for n ∈ 1:4)
+    @test all(y_voa[n] == fill(ones(Vec3), n) for n in 1:4)
 end


### PR DESCRIPTION
This PR fixes `recursivefill!` when attempting to fill a `VectorOfArray` in which the element type is some sort of `StaticArray`.

Here is a minimal example:

```julia
using RecursiveArrayTools
using StaticArrays

A = VectorOfArray([randn(SVector{3, Float64}, i) for i ∈ 1:4])   # A[i] is a Vector{SVector{...}}

B = recursivecopy(A)
recursivefill!(B, zero(eltype(B)))

C = recursivecopy(A)
recursivefill!(C, false)
```

In the current master, the calls to `recursivefill!` respectively fail with:

```julia
1. ERROR: MethodError: Cannot `convert` an object of type Float64 to an object of type SVector{3, Float64}                                                                                                           

2. ERROR: MethodError: no method matching fill(::Bool, ::Type{Vector{SVector{3, Float64}}})
```

This is because, in the called `recursivefill!` variants, it is assumed that `B[i] isa eltype(B)`, which is generally the case for `AbstractArray`s. This condition is however violated by `VectorOfArray` (since in this case `B[i]` is an `AbstractVector{eltype(B)}`).

This is fixed in this PR by adding specialisations of `recursivefill!` for `AbstractVectorOfArray{<:StaticArray}`.