### PR TITLE
fix UndefVarError: `_throw_dmrs` not defined

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -394,7 +394,7 @@ end
 
 function Base._reshape(parent::VectorOfArray, dims::Base.Dims)
     n = prod(size(parent))
-    prod(dims) == n || _throw_dmrs(n, "size", dims)
+    prod(dims) == n || Base._throw_dmrs(n, "size", dims)
     Base.__reshape((parent, IndexStyle(parent)), dims)
 end
 


### PR DESCRIPTION
Improves the error message in #271.