### PR TITLE
Remove type constraints for copy of ArrayPartition

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -81,7 +81,7 @@ function Base.similar(A::ArrayPartition, ::Type{T}, ::Type{S}, R::DataType...) w
     ArrayPartition(f, N)
 end
 
-Base.copy(A::ArrayPartition{T, S}) where {T, S} = ArrayPartition{T, S}(copy.(A.x))
+Base.copy(A::ArrayPartition) = ArrayPartition(copy.(A.x))
 
 ## zeros
 Base.zero(A::ArrayPartition{T, S}) where {T, S} = ArrayPartition{T, S}(zero.(A.x))

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -81,10 +81,10 @@ function Base.similar(A::ArrayPartition, ::Type{T}, ::Type{S}, R::DataType...) w
     ArrayPartition(f, N)
 end
 
-Base.copy(A::ArrayPartition) = ArrayPartition(copy.(A.x))
+Base.copy(A::ArrayPartition) = ArrayPartition(map(copy, A.x))
 
 ## zeros
-Base.zero(A::ArrayPartition{T, S}) where {T, S} = ArrayPartition{T, S}(zero.(A.x))
+Base.zero(A::ArrayPartition) = ArrayPartition(map(zero, A.x))
 # ignore dims since array partitions are vectors
 Base.zero(A::ArrayPartition, dims::NTuple{N, Int}) where {N} = zero(A)
 

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -71,11 +71,13 @@ x = ArrayPartition([1, 2], [3.0, 4.0])
 
 # Copy
 @inferred copy(x)
+@inferred copy(ArrayPartition(x, x))
 
 # zero
 @inferred zero(x)
 @inferred zero(x, (2, 2))
 @inferred zero(x)
+@inferred zero(ArrayPartition(x, x))
 
 # ones
 @inferred ones(x)
@@ -230,11 +232,13 @@ begin
 end
 
 
-@testset "Copy with type changing array" begin
+@testset "Copy and zero with type changing array" begin
     # Motivating use case for this is ArrayPartitions of Arrow arrays which are mmap:ed and change type when copied 
     struct TypeChangingArray{T, N} <: AbstractArray{T, N} end
     Base.copy(::TypeChangingArray{T, N}) where {T,N} = Array{T,N}(undef, ntuple(_ -> 0, N)) 
+    Base.zero(::TypeChangingArray{T, N}) where {T,N} = zeros(T, ntuple(_ -> 0, N)) 
 
     a = ArrayPartition(TypeChangingArray{Int, 2}(), TypeChangingArray{Float32, 2}())
     @test copy(a) == ArrayPartition(zeros(Int, 0, 0), zeros(Float32, 0, 0))
+    @test zero(a) == ArrayPartition(zeros(Int, 0, 0), zeros(Float32, 0, 0))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,10 @@ using Test
 using Aqua
 using SafeTestsets
 
-Aqua.test_all(RecursiveArrayTools, ambiguities = false)
+if VERSION >= v"1.9"
+    Aqua.test_all(RecursiveArrayTools, ambiguities = false)
+end
+
 @test_broken isempty(Test.detect_ambiguities(RecursiveArrayTools))
 const GROUP = get(ENV, "GROUP", "All")
 const is_APPVEYOR = (Sys.iswindows() && haskey(ENV, "APPVEYOR"))


### PR DESCRIPTION
Fix #275 

Seems like it was ok to just remove all type constraints. I did a quick check with a dummy array type and the performance was identical to current main.

~~I tried to do the same thing for `zero`, but then it would no longer infer (even with the same construction as in the example in #275). Since I don't seem to need it for my use case I just left it as is.~~

Also did the same for `zero` since it had the same type of issue.

The tests might seem a bit silly. I put it in a separate commit in case you don't want it.