### PR TITLE
Fix Cartesian indexing into ArrayPartition

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -264,6 +264,8 @@ function Base._unsafe_getindex(::IndexStyle, A::ArrayPartition,
     return dest
 end
 
+Base._maybe_reshape(::IndexCartesian, A::ArrayPartition, I::Vararg{Union{Real, AbstractArray}, N}) where {N} = Vector(A)
+
 """
     setindex!(A::ArrayPartition, v, i::Int, j...)
 

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -242,3 +242,7 @@ end
     @test copy(a) == ArrayPartition(zeros(Int, 0, 0), zeros(Float32, 0, 0))
     @test zero(a) == ArrayPartition(zeros(Int, 0, 0), zeros(Float32, 0, 0))
 end
+
+@testset "Cartesian indexing" begin
+    @test ArrayPartition([1,2], [3])[1:3,1] == [1, 2, 3]
+end


### PR DESCRIPTION
This fixes #273 . Maybe not the most efficient but it is better than crashing.