### PR TITLE
fix: fix broadcasted assignment to VOA of StaticArrays

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -661,7 +661,7 @@ end
     bc = Broadcast.flatten(bc)
     N = narrays(bc)
     @inbounds for i in 1:N
-        if dest[:, i] isa AbstractArray
+        if dest[:, i] isa AbstractArray && !isa(dest[:, i], StaticArraysCore.SArray)
             copyto!(dest[:, i], unpack_voa(bc, i))
         else
             dest[:, i] = copy(unpack_voa(bc, i))

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -117,3 +117,11 @@ u = VectorOfArray([fill(2, SVector{2, Float64}), ones(SVector{2, Float64})])
 @test typeof(zero(u)) <: typeof(u)
 resize!(u,3)
 @test pointer(u) === pointer(u.u)
+
+# Ensure broadcast (including assignment) works with StaticArrays
+x = VectorOfArray([fill(2, SVector{2, Float64}), ones(SVector{2, Float64})])
+y = VectorOfArray([fill(2, SVector{2, Float64}), ones(SVector{2, Float64})])
+z = VectorOfArray([zeros(SVector{2, Float64}), zeros(SVector{2, Float64})])
+z .= x .+ y
+
+@test z == VectorOfArray([fill(4, SVector{2, Float64}), fill(2, SVector{2, Float64})])


### PR DESCRIPTION
## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
