### PR TITLE
fix: add utils methods for AbstractVectorOfArray, fix method overwriting on 1.10

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -423,7 +423,7 @@ ArrayInterface.zeromatrix(A::ArrayPartition) = ArrayInterface.zeromatrix(Vector(
 
 function __get_subtypes_in_module(mod, supertype; include_supertype = true, all=false, except=[])
     return filter([getproperty(mod, name) for name in names(mod; all) if !in(name, except)]) do value
-            return value isa Type && (value <: supertype) && (include_supertype || value != supertype) && !in(value, except)
+            return value != Union{} && value isa Type && (value <: supertype) && (include_supertype || value != supertype) && !in(value, except)
         end
 end
 

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -488,6 +488,9 @@ end
 function Base.checkbounds(VA::AbstractVectorOfArray, idx...)
     checkbounds(Bool, VA, idx...) || throw(BoundsError(VA, idx))
 end
+function Base.copyto!(dest::AbstractVectorOfArray{T,N}, src::AbstractVectorOfArray{T,N}) where {T,N}
+    copyto!.(dest.u, src.u)
+end
 
 # Operations
 function Base.isapprox(A::AbstractVectorOfArray,
@@ -544,7 +547,6 @@ end
 @inline function Base.similar(VA::VectorOfArray, ::Type{T} = eltype(VA)) where {T}
     VectorOfArray([similar(VA[:, i], T) for i in eachindex(VA.u)])
 end
-recursivecopy(VA::VectorOfArray) = VectorOfArray(copy.(VA.u))
 
 # fill!
 # For DiffEqArray it ignores ts and fills only u

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -3,7 +3,7 @@ using RecursiveArrayTools, Aqua
     Aqua.find_persistent_tasks_deps(RecursiveArrayTools)
     ambs = Aqua.detect_ambiguities(RecursiveArrayTools; recursive = true)
     @warn "Number of method ambiguities: $(length(ambs))"
-    @test length(ambs) <= 2
+    @test length(ambs) <= 1
     Aqua.test_deps_compat(RecursiveArrayTools)
     Aqua.test_piracies(RecursiveArrayTools)
     Aqua.test_project_extras(RecursiveArrayTools)

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -113,3 +113,13 @@ recursivefill!(x, true)
     recursivefill!(y_voa, ones(Vec3))
     @test all(y_voa[:, n] == fill(ones(Vec3), n) for n in 1:4)
 end
+
+@testset "VectorOfArray recursivecopy!" begin
+    u1 = VectorOfArray([fill(2, MVector{2, Float64}), ones(MVector{2, Float64})])
+    u2 = VectorOfArray([fill(4, MVector{2, Float64}), 2 .* ones(MVector{2, Float64})])
+    recursivecopy!(u1,u2)
+    @test u1.u[1] == [4.0,4.0]
+    @test u1.u[2] == [2.0,2.0]
+    @test u1.u[1] isa MVector
+    @test u1.u[2] isa MVector
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
