### PR TITLE
fix: allow setting VoA of SArray using scalars

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -681,7 +681,12 @@ end
             copyto!(dest[:, i], unpack_voa(bc, i))
         else
             unpacked = unpack_voa(bc, i)
-            dest[:, i] = unpacked.f(unpacked.args...)
+            value = unpacked.f(unpacked.args...)
+            dest[:, i] = if value isa Number && dest[:, i] isa AbstractArray
+                fill(value, StaticArraysCore.similar_type(dest[:, i]))
+            else
+                value
+            end
         end
     end
     dest

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -152,3 +152,9 @@ f!(z,zz)
 
 z .= 0.1
 @test z == VectorOfArray([fill(0.1, SVector{2, Float64}), fill(0.1, SVector{2, Float64})])
+
+function f2!(z)
+    z .= 0.1
+end
+f2!(z)
+@test (@allocated f2!(z)) == 0

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -149,3 +149,6 @@ function f!(z,zz)
 end
 f!(z,zz)
 @test (@allocated f!(z,zz)) == 0
+
+z .= 0.1
+@test z == VectorOfArray([fill(0.1, SVector{2, Float64}), fill(0.1, SVector{2, Float64})])


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
