### PR TITLE
fix: add support for adjoint of AbstractVectorOfArray

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -347,6 +347,10 @@ Base.@propagate_inbounds function Base.getindex(A::AbstractVectorOfArray, _arg, 
     end
 end
 
+Base.@propagate_inbounds function Base.getindex(A::Adjoint{T,<:AbstractVectorOfArray}, idxs...) where {T}
+    return getindex(A.parent, reverse(to_indices(A, idxs))...)
+end
+
 function _observed(A::AbstractDiffEqArray{T, N}, sym, i::Int) where {T, N}
     observed(A, sym)(A.u[i], A.p, A.t[i])
 end
@@ -395,6 +399,9 @@ end
 
 # Interface for the two-dimensional indexing, a more standard AbstractArray interface
 @inline Base.size(VA::AbstractVectorOfArray) = (size(VA.u[1])..., length(VA.u))
+@inline Base.size(VA::AbstractVectorOfArray, i) = size(VA)[i]
+@inline Base.size(A::Adjoint{T,<:AbstractVectorOfArray}) where {T} = reverse(size(A.parent))
+@inline Base.size(A::Adjoint{T,<:AbstractVectorOfArray}, i) where {T} = size(A)[i]
 Base.axes(VA::AbstractVectorOfArray) = Base.OneTo.(size(VA))
 Base.axes(VA::AbstractVectorOfArray, d::Int) = Base.OneTo(size(VA)[d])
 
@@ -592,6 +599,7 @@ end
 @inline Statistics.var(VA::AbstractVectorOfArray; kwargs...) = var(Array(VA); kwargs...)
 @inline Statistics.cov(VA::AbstractVectorOfArray; kwargs...) = cov(Array(VA); kwargs...)
 @inline Statistics.cor(VA::AbstractVectorOfArray; kwargs...) = cor(Array(VA); kwargs...)
+@inline Base.adjoint(VA::AbstractVectorOfArray) = Adjoint(VA)
 
 # make it show just like its data
 function Base.show(io::IO, m::MIME"text/plain", x::AbstractVectorOfArray)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -48,3 +48,10 @@ for T in (Array{Float64}, Array{ComplexF64})
         @test d.x[i] == b.x[i] * c.x[i]
     end
 end
+
+va = VectorOfArray([i * ones(3) for i in 1:4])
+mat = Array(va)
+
+@test size(va') == (size(va', 1), size(va', 2)) == (size(va, 2), size(va, 1))
+@test all(va'[i] == mat'[i] for i in eachindex(mat'))
+@test Array(va') == mat'


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
