### PR TITLE
fix: VoA stack, ArrayPartition arithmetic type stability

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -499,7 +499,7 @@ function Base.append!(VA::AbstractVectorOfArray{T, N},
 end
 
 function Base.stack(VA::AbstractVectorOfArray; dims = :)
-    stack(VA.u; dims)
+    stack(stack.(VA.u); dims)
 end
 
 # AbstractArray methods
@@ -633,7 +633,7 @@ function Base.convert(::Type{Array}, VA::AbstractVectorOfArray)
     if !allequal(size.(VA.u))
         error("Can only convert non-ragged VectorOfArray to Array")
     end
-    return stack(VA.u)
+    return stack(VA)
 end
 
 # statistics

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -109,6 +109,9 @@ end
 @test stack(testva) == [1 4 7; 2 5 8; 3 6 9]
 @test stack(testva; dims = 1) == [1 2 3; 4 5 6; 7 8 9]
 
+testva = VectorOfArray([VectorOfArray([ones(2,2), 2ones(2, 2)]), 3ones(2, 2, 2)])
+@test stack(testva) == [1.0 1.0; 1.0 1.0;;; 2.0 2.0; 2.0 2.0;;;; 3.0 3.0; 3.0;;; 3.0 3.0; 3.0 3.0]
+
 # convert array from VectorOfArray/DiffEqArray
 t = 1:8
 recs = [rand(10, 7) for i in 1:8]

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -110,7 +110,7 @@ end
 @test stack(testva; dims = 1) == [1 2 3; 4 5 6; 7 8 9]
 
 testva = VectorOfArray([VectorOfArray([ones(2,2), 2ones(2, 2)]), 3ones(2, 2, 2)])
-@test stack(testva) == [1.0 1.0; 1.0 1.0;;; 2.0 2.0; 2.0 2.0;;;; 3.0 3.0; 3.0;;; 3.0 3.0; 3.0 3.0]
+@test stack(testva) == [1.0 1.0; 1.0 1.0;;; 2.0 2.0; 2.0 2.0;;;; 3.0 3.0; 3.0 3.0;;; 3.0 3.0; 3.0 3.0]
 
 # convert array from VectorOfArray/DiffEqArray
 t = 1:8

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -58,6 +58,7 @@ copyto!(p, c)
 ## inference tests
 
 x = ArrayPartition([1, 2], [3.0, 4.0])
+y = ArrayPartition(ArrayPartition([1], [2.0]), ArrayPartition([3], [4.0]))
 @test x[:, 1] == (1, 3.0)
 
 # similar partitions
@@ -68,6 +69,13 @@ x = ArrayPartition([1, 2], [3.0, 4.0])
 @test similar(x, Int, (4,)) isa ArrayPartition{Int}
 @test (@inferred similar(x, Int, (2, 2))) isa AbstractMatrix{Int}
 # @inferred similar(x, Int, Float64)
+
+@inferred similar(y)
+@test similar(y, (4,)) isa ArrayPartition{Float64}
+@test (@inferred similar(y, (2, 2))) isa AbstractMatrix{Float64}
+@inferred similar(y, Int)
+@test similar(y, Int, (4,)) isa ArrayPartition{Int}
+@test (@inferred similar(y, Int, (2, 2))) isa AbstractMatrix{Int}
 
 # Copy
 @inferred copy(x)
@@ -95,6 +103,17 @@ x = ArrayPartition([1, 2], [3.0, 4.0])
 @inferred x + x
 @inferred x - x
 
+@inferred y + 5
+@inferred 5 + y
+@inferred y - 5
+@inferred 5 - y
+@inferred y * 5
+@inferred 5 * y
+@inferred y / 5
+@inferred 5 \ y
+@inferred y + y
+@inferred y - y
+
 # indexing
 @inferred first(x)
 @inferred last(x)
@@ -118,6 +137,7 @@ _scalar_op(y) = y + 1
 _broadcast_wrapper(y) = _scalar_op.(y)
 # Issue #8
 @inferred _broadcast_wrapper(x)
+@test_broken @inferred _broadcast_wrapper(y)
 
 # Testing map
 @test map(x -> x^2, x) == ArrayPartition(x.x[1] .^ 2, x.x[2] .^ 2)
@@ -151,11 +171,11 @@ function foo(y, x)
 end
 foo(xcde0, xce0)
 #@test 0 == @allocated foo(xcde0, xce0)
-function foo(y, x)
+function foo2(y, x)
     y .= y .+ 2 .* x
     nothing
 end
-foo(xcde0, xce0)
+foo2(xcde0, xce0)
 #@test 0 == @allocated foo(xcde0, xce0)
 
 # Custom AbstractArray types broadcasting


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
