### PR TITLE
fix: fix inference of `getindex(::ArrayPartition, ::Int)`

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -219,6 +219,7 @@ Base.@propagate_inbounds function Base.getindex(A::ArrayPartition, i::Int)
             return A.x[j][length(A.x[j]) + i]
         end
     end
+    throw(BoundsError(A, i))
 end
 
 """

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -1,6 +1,7 @@
 using RecursiveArrayTools, Test, Statistics, ArrayInterface
 A = (rand(5), rand(5))
 p = ArrayPartition(A)
+@inferred p[1]
 @test (p.x[1][1], p.x[2][1]) == (p[1], p[6])
 
 p = ArrayPartition(A, Val{true})


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
