### PR TITLE
Update Documenter to 1.3

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,5 +3,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [compat]
-Documenter = "1"
+Documenter = "1.3"
 RecursiveArrayTools = "3"


### PR DESCRIPTION
This enables the automatic writing of an `objects.inv` inventory file.

See https://discourse.julialang.org/t/ann-documenter-v1-3-0-inventories/111139

Technically, this PR doesn't do anything, since the next time the CI for building the documentation runs, it should be using the latest Documenter 1.3 anyway (based on the existing compat bound of "1"). The real motivation behind this PR is to trigger that CI to run when it is merged, so that https://docs.sciml.ai/RecursiveArrayTools/dev/objects.inv will exist, and I can use [DocumenterInterLinks](https://github.com/JuliaDocs/DocumenterInterLinks.jl) to link from my project into the documentation for `RecursiveArrayTools`. If you make a bugfix release based on this PR, the stable version inventory would exist at https://docs.sciml.ai/RecursiveArrayTools/stable/objects.inv, which would be even nicer.

You can also ignore this PR and manually run the CI to update the documentation for `dev` and/or the stable release, see the instructions at the very bottom of the Discourse post.