### PR TITLE
Fix multi-dimensional `VectorOfArray` broadcast

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -712,7 +712,7 @@ Base.eltype(::Type{<:AbstractVectorOfArray{T}}) where {T} = T
     end
 end
 @inline function Base.similar(VA::VectorOfArray, ::Type{T} = eltype(VA)) where {T}
-    VectorOfArray(similar.(Base.parent(VA), T))
+    VectorOfArray([similar(VA[:, i], T) for i in eachindex(VA.u)])
 end
 
 # for VectorOfArray with multi-dimensional parent arrays of arrays where all elements are the same type

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -28,8 +28,12 @@ the `VectorOfArray` into a matrix/tensor. Also, `vecarr_to_vectors(VA::AbstractV
 returns a vector of the series for each component, that is, `A[i,:]` for each `i`.
 A plot recipe is provided, which plots the `A[i,:]` series.
 
+<<<<<<< Updated upstream
 There is also support for `VectorOfArray` with constructed from multi-dimensional arrays
 
+=======
+There is also support for `VectorOfArray` constructed from multi-dimensional arrays
+>>>>>>> Stashed changes
 ```julia
 VectorOfArray(u::AbstractArray{AT}) where {T, N, AT <: AbstractArray{T, N}}
 ```
@@ -37,7 +41,7 @@ VectorOfArray(u::AbstractArray{AT}) where {T, N, AT <: AbstractArray{T, N}}
 where `IndexStyle(typeof(u)) isa IndexLinear`.
 """
 mutable struct VectorOfArray{T, N, A} <: AbstractVectorOfArray{T, N, A}
-    u::A # A <: AbstractVector{<: AbstractArray{T, N - 1}}
+    u::A # A <: AbstractArray{<: AbstractArray{T, N - 1}}
 end
 # VectorOfArray with an added series for time
 

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -717,19 +717,7 @@ Base.eltype(::Type{<:AbstractVectorOfArray{T}}) where {T} = T
     end
 end
 @inline function Base.similar(VA::VectorOfArray, ::Type{T} = eltype(VA)) where {T}
-    VectorOfArray([similar(VA[:, i], T) for i in eachindex(VA.u)])
-end
-
-# for VectorOfArray with multi-dimensional parent arrays of arrays where all elements are the same type
-function Base.similar(vec::VectorOfArray{
-        T, N, AT}) where {T, N, AT <: AbstractArray{<:AbstractArray{T}}}
-    return VectorOfArray(similar(Base.parent(vec)))
-end
-
-# special-case when the multi-dimensional parent array is just an AbstractVector (call the old method)
-function Base.similar(vec::VectorOfArray{
-        T, N, AT}) where {T, N, AT <: AbstractVector{<:AbstractArray{T}}}
-    return Base.similar(vec, eltype(vec))
+    VectorOfArray(similar.(Base.parent(VA), T))
 end
 
 # fill!

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -712,8 +712,21 @@ Base.eltype(::Type{<:AbstractVectorOfArray{T}}) where {T} = T
     end
 end
 @inline function Base.similar(VA::VectorOfArray, ::Type{T} = eltype(VA)) where {T}
-    VectorOfArray(similar.(Base.parent(VA), T))
+    VectorOfArray([similar(VA[:, i], T) for i in eachindex(VA.u)])
 end
+
+# for VectorOfArray with multi-dimensional parent arrays of arrays where all elements are the same type
+function Base.similar(vec::VectorOfArray{
+        T, N, AT}) where {T, N, AT <: AbstractArray{<:AbstractArray{T}}}
+    return VectorOfArray(similar.(Base.parent(vec)))
+end
+
+# special-case when the multi-dimensional parent array is just an AbstractVector (call the old method)
+function Base.similar(vec::VectorOfArray{
+        T, N, AT}) where {T, N, AT <: AbstractVector{<:AbstractArray{T}}}
+    return Base.similar(vec, eltype(vec))
+end
+
 
 # fill!
 # For DiffEqArray it ignores ts and fills only u

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -29,7 +29,6 @@ returns a vector of the series for each component, that is, `A[i,:]` for each `i
 A plot recipe is provided, which plots the `A[i,:]` series.
 
 There is also support for `VectorOfArray` constructed from multi-dimensional arrays
-
 ```julia
 VectorOfArray(u::AbstractArray{AT}) where {T, N, AT <: AbstractArray{T, N}}
 ```
@@ -352,53 +351,48 @@ Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::NotSymboli
 end
 
 struct ParameterIndexingError <: Exception
-    sym::Any
+    sym
 end
 
 function Base.showerror(io::IO, pie::ParameterIndexingError)
-    print(io,
-        "Indexing with parameters is deprecated. Use `getp(A, $(pie.sym))` for parameter indexing.")
+    print(io, "Indexing with parameters is deprecated. Use `getp(A, $(pie.sym))` for parameter indexing.")
 end
 
 # Symbolic Indexing Methods
 for (symtype, elsymtype, valtype, errcheck) in [
-    (ScalarSymbolic, SymbolicIndexingInterface.SymbolicTypeTrait,
-        Any, :(is_parameter(A, sym))),
-    (ArraySymbolic, SymbolicIndexingInterface.SymbolicTypeTrait,
-        Any, :(is_parameter(A, sym))),
-    (NotSymbolic, SymbolicIndexingInterface.SymbolicTypeTrait,
-        Union{<:Tuple, <:AbstractArray},
-        :(all(x -> is_parameter(A, x), sym)))
+    (ScalarSymbolic, SymbolicIndexingInterface.SymbolicTypeTrait, Any, :(is_parameter(A, sym))),
+    (ArraySymbolic, SymbolicIndexingInterface.SymbolicTypeTrait, Any, :(is_parameter(A, sym))),
+    (NotSymbolic, SymbolicIndexingInterface.SymbolicTypeTrait, Union{<:Tuple, <:AbstractArray}, 
+        :(all(x -> is_parameter(A, x), sym))),
 ]
-    @eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
-            ::$elsymtype, sym::$valtype)
-        if $errcheck
-            throw(ParameterIndexingError(sym))
-        end
-        getu(A, sym)(A)
+@eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
+        ::$elsymtype, sym::$valtype)
+    if $errcheck
+        throw(ParameterIndexingError(sym))
     end
-    @eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
-            ::$elsymtype, sym::$valtype, arg)
-        if $errcheck
-            throw(ParameterIndexingError(sym))
-        end
-        getu(A, sym)(A, arg)
+    getu(A, sym)(A)
+end
+@eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
+        ::$elsymtype, sym::$valtype, arg)
+    if $errcheck
+        throw(ParameterIndexingError(sym))
     end
-    @eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
-            ::$elsymtype, sym::$valtype, arg::Union{
-                AbstractArray{Int}, AbstractArray{Bool}})
-        if $errcheck
-            throw(ParameterIndexingError(sym))
-        end
-        getu(A, sym).((A,), arg)
+    getu(A, sym)(A, arg)
+end
+@eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
+        ::$elsymtype, sym::$valtype, arg::Union{AbstractArray{Int}, AbstractArray{Bool}})
+    if $errcheck
+        throw(ParameterIndexingError(sym))
     end
-    @eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
-            ::$elsymtype, sym::$valtype, ::Colon)
-        if $errcheck
-            throw(ParameterIndexingError(sym))
-        end
-        getu(A, sym)(A)
+    getu(A, sym).((A,), arg)
+end
+@eval Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::$symtype,
+        ::$elsymtype, sym::$valtype, ::Colon)
+    if $errcheck
+        throw(ParameterIndexingError(sym))
     end
+    getu(A, sym)(A)
+end
 end
 
 Base.@propagate_inbounds function _getindex(A::AbstractDiffEqArray, ::ScalarSymbolic,
@@ -416,9 +410,8 @@ Base.@propagate_inbounds function Base.getindex(A::AbstractVectorOfArray, _arg, 
     elsymtype = symbolic_type(eltype(_arg))
 
     if symtype == NotSymbolic() && elsymtype == NotSymbolic()
-        if _arg isa Union{Tuple, AbstractArray} &&
-           any(x -> symbolic_type(x) != NotSymbolic(), _arg)
-            _getindex(A, symtype, elsymtype, _arg, args...)
+        if _arg isa Union{Tuple, AbstractArray} && any(x -> symbolic_type(x) != NotSymbolic(), _arg)
+        _getindex(A, symtype, elsymtype, _arg, args...)
         else
             _getindex(A, symtype, _arg, args...)
         end
@@ -733,6 +726,7 @@ function Base.similar(vec::VectorOfArray{
         T, N, AT}) where {T, N, AT <: AbstractVector{<:AbstractArray{T}}}
     return Base.similar(vec, eltype(vec))
 end
+
 
 # fill!
 # For DiffEqArray it ignores ts and fills only u

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -28,12 +28,7 @@ the `VectorOfArray` into a matrix/tensor. Also, `vecarr_to_vectors(VA::AbstractV
 returns a vector of the series for each component, that is, `A[i,:]` for each `i`.
 A plot recipe is provided, which plots the `A[i,:]` series.
 
-<<<<<<< Updated upstream
-There is also support for `VectorOfArray` with constructed from multi-dimensional arrays
-
-=======
 There is also support for `VectorOfArray` constructed from multi-dimensional arrays
->>>>>>> Stashed changes
 ```julia
 VectorOfArray(u::AbstractArray{AT}) where {T, N, AT <: AbstractArray{T, N}}
 ```

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -248,13 +248,13 @@ function foo!(u)
 end
 foo!(u_matrix)
 foo!(u_vector)
-@test all(u_matrix .== [3, 10]) 
+@test all(u_matrix .== [3, 10])
 @test all(vec(u_matrix) .≈ vec(u_vector))
 
 # test that, for VectorOfArray with multi-dimensional parent arrays,
 # broadcast and `similar` preserve the structure of the parent array
 @test typeof(parent(similar(u_matrix))) == typeof(parent(u_matrix))
-@test typeof(parent((x->x).(u_matrix))) == typeof(parent(u_matrix)) 
+@test typeof(parent((x -> x).(u_matrix))) == typeof(parent(u_matrix))
 
 # test efficiency 
 num_allocs = @allocations foo!(u_matrix)

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -238,8 +238,8 @@ a[[1, 3, 8]]
 # multidimensional array of arrays
 ####################################################################
 
-u_matrix = VectorOfArray(fill([1, 2], 2, 3))
-u_vector = VectorOfArray(vec(u_matrix.u))
+u_matrix = VectorOfArray([[1, 2] for i in 1:2, j in 1:3])
+u_vector = VectorOfArray([[1, 2] for i in 1:6])
 
 # test broadcasting 
 function foo!(u)
@@ -248,7 +248,8 @@ function foo!(u)
 end
 foo!(u_matrix)
 foo!(u_vector)
-@test u_matrix ≈ u_vector
+@test all(u_matrix .== [3, 10]) 
+@test all(vec(u_matrix) .≈ vec(u_vector))
 
 # test that, for VectorOfArray with multi-dimensional parent arrays,
 # `similar` preserves the structure of the parent array

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -252,8 +252,9 @@ foo!(u_vector)
 @test all(vec(u_matrix) .≈ vec(u_vector))
 
 # test that, for VectorOfArray with multi-dimensional parent arrays,
-# `similar` preserves the structure of the parent array
+# broadcast and `similar` preserve the structure of the parent array
 @test typeof(parent(similar(u_matrix))) == typeof(parent(u_matrix))
+@test typeof(parent((x->x).(u_matrix))) == typeof(parent(u_matrix)) 
 
 # test efficiency 
 num_allocs = @allocations foo!(u_matrix)

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -248,13 +248,13 @@ function foo!(u)
 end
 foo!(u_matrix)
 foo!(u_vector)
-@test all(u_matrix .== [3, 10])
+@test all(u_matrix .== [3, 10]) 
 @test all(vec(u_matrix) .≈ vec(u_vector))
 
 # test that, for VectorOfArray with multi-dimensional parent arrays,
 # broadcast and `similar` preserve the structure of the parent array
 @test typeof(parent(similar(u_matrix))) == typeof(parent(u_matrix))
-@test typeof(parent((x -> x).(u_matrix))) == typeof(parent(u_matrix))
+@test typeof(parent((x->x).(u_matrix))) == typeof(parent(u_matrix)) 
 
 # test efficiency 
 num_allocs = @allocations foo!(u_matrix)


### PR DESCRIPTION
Addresses https://github.com/SciML/RecursiveArrayTools.jl/issues/373

The fix just involves modifying `Base.copy` for `VectorOfArray` with multi-dimensional parent arrays. This could replace the old `Base.copy` implementation, but I left the old implementation there just in case it changes behavior upstream.
