### PR TITLE
Device agnostic convert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.16.0"
+version = "3.16.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -135,6 +135,9 @@ function Base.Array{U}(VA::AbstractVectorOfArray) where {U}
     vecs = vec.(VA.u)
     Array(reshape(reduce(hcat, vecs), size(VA.u[1])..., length(VA.u)))
 end
+
+Base.convert(::Type{AbstractArray}, VA::AbstractVectorOfArray) = stack(VA.u)
+
 function Adapt.adapt_structure(to, VA::AbstractVectorOfArray)
     Adapt.adapt(to, Array(VA))
 end

--- a/test/gpu/vectorofarray_gpu.jl
+++ b/test/gpu/vectorofarray_gpu.jl
@@ -31,3 +31,9 @@ function f(p)
     sum(CuArray(x))
 end
 Zygote.gradient(f, p)
+
+# Check conversion preserves device
+va_cu = convert(AbstractArray, va)
+
+@test va_cu isa CuArray
+@test size(va_cu) == size(x)


### PR DESCRIPTION
Needs testing.

Basically we can now use `convert(AbstractArray, x)` to do a device agnostic convert.