### PR TITLE
Remove projection rule for `VectorOfArray`

### DIFF
--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -139,19 +139,19 @@ end
     view(A, I...), view_adjoint
 end
 
-function ChainRulesCore.ProjectTo(a::AbstractVectorOfArray)
-    ChainRulesCore.ProjectTo{VectorOfArray}((sz = size(a)))
-end
-
-function (p::ChainRulesCore.ProjectTo{VectorOfArray})(x::Union{
-        AbstractArray, AbstractVectorOfArray})
-    if eltype(x) <: Number
-        arr = reshape(x, p.sz)
-        return VectorOfArray([arr[:, i] for i in 1:p.sz[end]])
-    elseif eltype(x) <: AbstractArray
-        return VectorOfArray(x)
-    end
-end
+# function ChainRulesCore.ProjectTo(a::AbstractVectorOfArray)
+#     ChainRulesCore.ProjectTo{VectorOfArray}((sz = size(a)))
+# end
+# 
+# function (p::ChainRulesCore.ProjectTo{VectorOfArray})(x::Union{
+#         AbstractArray, AbstractVectorOfArray})
+#     if eltype(x) <: Number
+#         arr = reshape(x, p.sz)
+#         return VectorOfArray([arr[:, i] for i in 1:p.sz[end]])
+#     elseif eltype(x) <: AbstractArray
+#         return VectorOfArray(x)
+#     end
+# end
 
 @adjoint function Broadcast.broadcasted(::typeof(+), x::AbstractVectorOfArray,
         y::Union{Zygote.Numeric, AbstractVectorOfArray})

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -139,19 +139,6 @@ end
     view(A, I...), view_adjoint
 end
 
-# function ChainRulesCore.ProjectTo(a::AbstractVectorOfArray)
-#     ChainRulesCore.ProjectTo{VectorOfArray}((sz = size(a)))
-# end
-# 
-# function (p::ChainRulesCore.ProjectTo{VectorOfArray})(x::Union{
-#         AbstractArray, AbstractVectorOfArray})
-#     if eltype(x) <: Number
-#         arr = reshape(x, p.sz)
-#         return VectorOfArray([arr[:, i] for i in 1:p.sz[end]])
-#     elseif eltype(x) <: AbstractArray
-#         return VectorOfArray(x)
-#     end
-# end
 
 @adjoint function Broadcast.broadcasted(::typeof(+), x::AbstractVectorOfArray,
         y::Union{Zygote.Numeric, AbstractVectorOfArray})


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

The current rule does not account for the various Tangent types that can be seen when working with downstream packages (specifically note AD'ing through observable functions via SII). It is much better to remove the rule and let AD take care of picking out the right fields etc. If its preferred to retain the rule (to get the VectorOfArray type returned in the reverse pass), then we will need to handle that elsewhere. For now, let's check for breakages in CI.

Add any other context about the problem here.
