### PR TITLE
feat: add `ndims` method for `::Type{<:AbstractVectorOfArray}`

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -609,6 +609,7 @@ function Base.check_parent_index_match(
     nothing
 end
 Base.ndims(::AbstractVectorOfArray{T, N}) where {T, N} = N
+Base.ndims(::Type{<:AbstractVectorOfArray{T, N}}) where {T, N} = N
 
 function Base.checkbounds(
         ::Type{Bool}, VA::AbstractVectorOfArray{T, N, <:AbstractVector{T}},

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -50,6 +50,10 @@ push!(testda, [-1, -2, -3, -4])
 @test testda[:, 9] == [-1, -2, -3, -4]
 @test testda[:, end] == [-1, -2, -3, -4]
 
+# ndims
+@test ndims(testva) == 2
+@test ndims(typeof(testva)) == 2
+
 # Currently we enforce the general shape, they can just be different lengths, ie we
 # can't do
 # Decide if this is desired, or remove this restriction


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
