### PR TITLE
chore: set indexing style

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -265,6 +265,8 @@ function Base._maybe_reshape(::IndexCartesian,
     Vector(A)
 end
 
+Base.IndexStyle(::ArrayPartition) = IndexLinear()
+
 ## recursive methods
 
 function recursivecopy!(A::ArrayPartition, B::ArrayPartition)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

ReverseDiff restricts array types to `IndexLinear()` indexing style as written in their docs: https://juliadiff.org/ReverseDiff.jl/dev/limits/

Not following this causes failures with using ReverseDiff:

```julia
@parameters σ ρ β
@variables x(t) y(t) z(t)

eqs = [D(D(x)) ~ σ * (y - x),
    D(y) ~ x * (ρ - z) - y,
    D(z) ~ x * y - β * z,
    w ~ x + y + z + 2 * β,
    ]

@mtkbuild sys = ODESystem(eqs, t)

ModelingToolkit.observed(sys)

u0 = [D(x) => 2.0,
    x => 1.0,
    y => 0.0,
    z => 0.0,]

p = [σ => 28.0,
    ρ => 10.0,
    β => 8 / 3,]

tspan = (0.0, 100.0)
prob = ODEProblem(sys, u0, tspan, p, jac = true)
sol = solve(prob, Tsit5())

mtkp = parameter_values(sol)
gt = rand(873)

gradient(mtkparams) do p
    sol = solve(prob, Rosenbrock23(), p = p, sensealg = SciMLSensitivity.GaussAdjoint(autojacvec = ReverseDiffVJP()))
    mean(abs.(sol[sys.x] .- gt))
end
```

cc @AayushSabharwal 

Add any other context about the problem here.
