### PR TITLE
Fix broadcast failure for `VectorOfArray` with `SVector{1}`

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -905,8 +905,10 @@ for (type, N_expr) in [
                 else
                     unpacked = unpack_voa(bc, i)
                     arr_type = StaticArraysCore.similar_type(dest[:, i])
-                    dest[:, i] = if length(unpacked) == 1
+                    dest[:, i] = if length(unpacked) == 1 && length(dest[:, i]) == 1
                         arr_type(unpacked[1])
+                    elseif length(unpacked) == 1
+                        fill(copy(unpacked), arr_type)
                     else
                         arr_type(unpacked[j] for j in eachindex(unpacked))
                     end

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -906,7 +906,7 @@ for (type, N_expr) in [
                     unpacked = unpack_voa(bc, i)
                     arr_type = StaticArraysCore.similar_type(dest[:, i])
                     dest[:, i] = if length(unpacked) == 1
-                        fill(copy(unpacked), arr_type)
+                        arr_type(unpacked[1])
                     else
                         arr_type(unpacked[j] for j in eachindex(unpacked))
                     end

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -83,7 +83,7 @@ b = recursivecopy(a)
 a[1] *= 2
 @test a[1] != b[1]
 
-# Broadcasting when SVector{1}
+# Broadcasting when SVector{N} where N = 1
 a = [SVector(0.0) for _ in 1:2]
 a_voa = VectorOfArray(a)
 b_voa = copy(a_voa)
@@ -92,6 +92,12 @@ a_voa[2] = SVector(1.0)
 @. b_voa = a_voa
 @test b_voa[1] == a_voa[1]
 @test b_voa[2] == a_voa[2]
+
+a = [SVector(0.0) for _ in 1:2]
+a_voa = VectorOfArray(a)
+a_voa .= 1.0
+@test a_voa[1] == SVector(1.0)
+@test a_voa[2] == SVector(1.0)
 
 # Broadcasting when SVector{N} where N > 1
 a = [SVector(0.0, 0.0) for _ in 1:2]
@@ -102,3 +108,9 @@ a_voa[2] = SVector(1.0, 1.0)
 @. b_voa = a_voa
 @test b_voa[1] == a_voa[1]
 @test b_voa[2] == a_voa[2]
+
+a = [SVector(0.0, 0.0) for _ in 1:2]
+a_voa = VectorOfArray(a)
+a_voa .= 1.0
+@test a_voa[1] == SVector(1.0, 1.0)
+@test a_voa[2] == SVector(1.0, 1.0)

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -82,3 +82,23 @@ b = recursivecopy(a)
 @test a[1] == b[1]
 a[1] *= 2
 @test a[1] != b[1]
+
+# Broadcasting when SVector{1}
+a = [SVector(0.0) for _ in 1:2]
+a_voa = VectorOfArray(a)
+b_voa = copy(a_voa)
+a_voa[1] = SVector(1.0)
+a_voa[2] = SVector(1.0)
+@. b_voa = a_voa
+@test b_voa[1] == a_voa[1]
+@test b_voa[2] == a_voa[2]
+
+# Broadcasting when SVector{N} where N > 1
+a = [SVector(0.0, 0.0) for _ in 1:2]
+a_voa = VectorOfArray(a)
+b_voa = copy(a_voa)
+a_voa[1] = SVector(1.0, 1.0)
+a_voa[2] = SVector(1.0, 1.0)
+@. b_voa = a_voa
+@test b_voa[1] == a_voa[1]
+@test b_voa[2] == a_voa[2]


### PR DESCRIPTION
Fix #378.

The corner case was considered but was never included in tests, so the error was not caught during development.
