### PR TITLE
fix: do not assume `AbstractVectorOfArray` is mutable in `Base.zero`

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -521,7 +521,7 @@ end
 
 function Base.zero(VA::AbstractVectorOfArray)
     val = copy(VA)
-    val.u = zero.(VA.u)
+    val.u .= zero.(VA.u)
     return val
 end
 

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -269,3 +269,13 @@ end
 f3!(z, zz)
 @test z == VectorOfArray([fill(4, SVector{2, Float64}), fill(2, SVector{2, Float64})])
 @test (@allocated f3!(z, zz)) == 0
+
+struct ImmutableVectorOfArray{T, N, A} <: AbstractVectorOfArray{T, N, A}
+    u::A # A <: AbstractArray{<: AbstractArray{T, N - 1}}
+end
+
+@testset "Base.zero does not assume mutable struct" begin
+    voa = ImmutableVectorOfArray{Float64, 2, Vector{Vector{Float64}}}([ones(3), 2ones(3)])
+    zvoa = zero(voa)
+    @test zvoa.u[1] == zvoa.u[2] == zeros(3)
+end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -56,4 +56,4 @@ mat = Array(va)
 @test all(va'[i] == mat'[i] for i in eachindex(mat'))
 @test Array(va') == mat'
 
-@test !ArrayInterface.issingular(VectorOfArray([rand(2),rand(2)]))
+@test !ArrayInterface.issingular(VectorOfArray([rand(2), rand(2)]))

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -161,7 +161,6 @@ _scalar_op(y) = y + 1
 _broadcast_wrapper(y) = _scalar_op.(y)
 # Issue #8
 @inferred _broadcast_wrapper(x)
-@test_broken @inferred _broadcast_wrapper(y)
 
 # Testing map
 @test map(x -> x^2, x) == ArrayPartition(x.x[1] .^ 2, x.x[2] .^ 2)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
