### PR TITLE
Fix StructArray broadcast in VectorOfArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
@@ -33,6 +34,7 @@ RecursiveArrayToolsMeasurementsExt = "Measurements"
 RecursiveArrayToolsMonteCarloMeasurementsExt = "MonteCarloMeasurements"
 RecursiveArrayToolsReverseDiffExt = ["ReverseDiff", "Zygote"]
 RecursiveArrayToolsSparseArraysExt = ["SparseArrays"]
+RecursiveArrayToolsStructArraysExt = "StructArrays"
 RecursiveArrayToolsTrackerExt = "Tracker"
 RecursiveArrayToolsZygoteExt = "Zygote"
 

--- a/ext/RecursiveArrayToolsStructArraysExt.jl
+++ b/ext/RecursiveArrayToolsStructArraysExt.jl
@@ -1,0 +1,6 @@
+module RecursiveArrayToolsStructArraysExt
+
+import RecursiveArrayTools, StructArrays
+RecursiveArrayTools.rewrap(::StructArrays.StructArray, u) = StructArrays.StructArray(u)
+
+end

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -874,8 +874,6 @@ for (type, N_expr) in [
 ]
     @eval @inline function Base.copyto!(dest::AbstractVectorOfArray,
             bc::$type)
-            @show typeof(dest)
-            error()
         bc = Broadcast.flatten(bc)
         N = $N_expr
         @inbounds for i in 1:N

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -114,3 +114,10 @@ a_voa = VectorOfArray(a)
 a_voa .= 1.0
 @test a_voa[1] == SVector(1.0, 1.0)
 @test a_voa[2] == SVector(1.0, 1.0)
+
+#Broadcast Copy of StructArray
+x = StructArray{SVector{2, Float64}}((randn(2), randn(2)))
+vx = VectorOfArray(x)
+vx2 = copy(vx) .+ 1
+ans = vx .+ vx2
+@test ans.u isa StructArray


### PR DESCRIPTION
Fixes https://github.com/SciML/RecursiveArrayTools.jl/issues/410

This specializes so that if `u.u` is not a vector, it will convert the broadcast to fix that. I couldn't find a nice generic way to use `map` so the fallback is to build the vector and convert, which seems to not be a big performance issue. For StructArrays, `convert(typeof(x), Vector(x))` fails, and so this case is specialized.
