### PR TITLE
Make ArrayPartitions of GPU arrays work in DifferentialEquations solvers

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -209,6 +209,13 @@ function Base.copyto!(A::ArrayPartition, src::ArrayPartition)
     A
 end
 
+function recursivefill!(b::ArrayPartition, a::T2) where {T2 <: Union{Number, Bool}}
+    unrolled_foreach!(b.x) do x
+        fill!(x, a)
+    end
+end
+
+
 ## indexing
 
 # Interface for the linear indexing. This is just a view of the underlying nested structure

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,7 @@
+unrolled_foreach!(f, t::Tuple) = (f(t[1]); unrolled_foreach!(f, Base.tail(t)))
+unrolled_foreach!(f, ::Tuple{}) = nothing
+
+
 """
 ```julia
 recursivecopy(a::Union{AbstractArray{T, N}, AbstractVectorOfArray{T, N}})
@@ -126,6 +130,7 @@ function recursivefill!(bs::AbstractVectorOfArray{T, N},
         b[i] = fill(a, typeof(b[i]))
     end
 end
+
 
 for type in [AbstractArray, AbstractVectorOfArray]
     @eval function recursivefill!(b::$type{T, N}, a::T2) where {T <: Enum, T2 <: Enum, N}

--- a/test/gpu/arraypartition_gpu.jl
+++ b/test/gpu/arraypartition_gpu.jl
@@ -1,0 +1,16 @@
+using RecursiveArrayTools, CUDA, Test
+CUDA.allowscalar(false)
+
+
+# Test indexing with colon
+a = (CUDA.zeros(5), CUDA.zeros(5))
+pA = ArrayPartition(a)
+pA[:, :]
+
+# Indexing with boolean masks does not work yet
+mask = pA .> 0
+# pA[mask]
+
+# Test recursive filling is done using GPU kernels and not scalar indexing
+RecursiveArrayTools.recursivefill!(pA, true)
+@test all(pA .== true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,5 +54,6 @@ end
     if GROUP == "GPU"
         activate_gpu_env()
         @time @safetestset "VectorOfArray GPU" include("gpu/vectorofarray_gpu.jl")
+        @time @safetestset "ArrayPartition GPU" include("gpu/arraypartition_gpu.jl")
     end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [Tests Pass] Any code changes were done in a way that does not break public API
- [NA] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [NA] Any new documentation only uses public API

## Additional context

The only function that was preventing ArrayPartitions of GPU arrays to work in DifferentialEquations solvers was `recursivefill!`, which was deferring to `Base.fill!` with scalar indexing. This PR makes fixes two things:

- `recursivefill!` calls `fill!` on each array within the `ArrayPartitions.x` tuple - which now defer to the right GPU kernels.
- Filling does not require index recalculations for each `setindex!` - which was unnecessary work.

Example Code (similar to what was added to the tests):
```julia
using RecursiveArrayTools
using Metal

a = (Metal.rand(5), Metal.rand(5))
pA = ArrayPartition(a)

# This now works
RecursiveArrayTools.recursivefill!(pA, false)
```

## Possible Issues
- I added an `unrolled_foreach(f, x::Tuple)` implementation for type stability when calling `fill!` on each subarray in the `ArrayPartition.x` tuple. This now uses a closure for `f` which updates each subarray inline; it is type-stable when checking with Cthulhu, and it does not update any variable outside the closure; I see the SciML guidelines do not recommend closures - should I rewrite that as a struct and all that?
- I added a specialised implementation of `recursivefill!` for `ArrayPartitions`; all tests seem to work, but I don't have the "bigger picture" of how this is used across the ecosystem - is this okay / non-ambiguous? Should the other `recursivefill!` implementations in `utils.jl` be changed?

