### PR TITLE
remove broadcast in `Base.similar` for `VectorOfArray` 

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -701,7 +701,7 @@ end
 
 function Base.similar(vec::VectorOfArray{
         T, N, AT}) where {T, N, AT <: AbstractArray{<:AbstractArray{T}}}
-    return VectorOfArray(similar.(Base.parent(vec)))
+    return VectorOfArray(similar(Base.parent(vec)))
 end
 
 @inline function Base.similar(VA::VectorOfArray, ::Type{T} = eltype(VA)) where {T}


### PR DESCRIPTION
Removes an unnecessary broadcast in `Base.similar` for `AbstractArray{<:AbstractArray}` types. This hopefully will resolve https://github.com/SciML/DiffEqBase.jl/issues/1110