### PR TITLE
Fix broadcast assignment for `VectorOfArray` with `StructArrays`

### DIFF
--- a/ext/RecursiveArrayToolsStructArraysExt.jl
+++ b/ext/RecursiveArrayToolsStructArraysExt.jl
@@ -3,7 +3,8 @@ module RecursiveArrayToolsStructArraysExt
 import RecursiveArrayTools, StructArrays
 RecursiveArrayTools.rewrap(::StructArrays.StructArray, u) = StructArrays.StructArray(u)
 
-using RecursiveArrayTools: VectorOfArray
+using RecursiveArrayTools: VectorOfArray, VectorOfArrayStyle, ArrayInterface, unpack_voa,
+                           narrays, StaticArraysCore
 using StructArrays: StructArray
 
 const VectorOfStructArray{T, N} = VectorOfArray{T, N, <:StructArray}
@@ -17,11 +18,45 @@ const VectorOfStructArray{T, N} = VectorOfArray{T, N, <:StructArray}
 # 
 # To avoid this, we can materialize a struct entry, modify it, and then use `setindex!` 
 # with the modified struct entry.
+# 
 function Base.setindex!(VA::VectorOfStructArray{T, N}, v,
         I::Int...) where {T, N}
     u_I = VA.u[I[end]]
     u_I[Base.front(I)...] = v
     return VA.u[I[end]] = u_I
+end
+
+for (type, N_expr) in [
+    (Broadcast.Broadcasted{<:VectorOfArrayStyle}, :(narrays(bc))),
+    (Broadcast.Broadcasted{<:Broadcast.DefaultArrayStyle}, :(length(dest.u)))
+]
+    @eval @inline function Base.copyto!(dest::VectorOfStructArray,
+            bc::$type)
+        bc = Broadcast.flatten(bc)
+        N = $N_expr
+        @inbounds for i in 1:N
+            dest_i = dest[:, i]
+            if dest_i isa AbstractArray
+                if ArrayInterface.ismutable(dest_i)
+                    copyto!(dest_i, unpack_voa(bc, i))
+                else
+                    unpacked = unpack_voa(bc, i)
+                    arr_type = StaticArraysCore.similar_type(dest_i)
+                    dest_i = if length(unpacked) == 1 && length(dest_i) == 1
+                        arr_type(unpacked[1])
+                    elseif length(unpacked) == 1
+                        fill(copy(unpacked), arr_type)
+                    else
+                        arr_type(unpacked[j] for j in eachindex(unpacked))
+                    end
+                end
+            else
+                dest_i = copy(unpack_voa(bc, i))
+            end
+            dest[:, i] = dest_i
+        end
+        dest
+    end
 end
 
 end

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -265,9 +265,18 @@ num_allocs = @allocations foo!(u_matrix)
 
 # check VectorOfArray indexing for a StructArray of mutable structs
 using StructArrays
-using StaticArrays: MVector
+using StaticArrays: MVector, SVector
 x = VectorOfArray(StructArray{MVector{1, Float64}}(ntuple(_ -> [1.0, 2.0], 1)))
+y = 2 * x
 
-# check VectorOfArray assignment 
+# check mutable VectorOfArray assignment and broadcast
 x[1, 1] = 10
 @test x[1, 1] == 10
+@. x = y
+@test all(all.(y .== x))
+
+# check immutable VectorOfArray broadcast
+x = VectorOfArray(StructArray{SVector{1, Float64}}(ntuple(_ -> [1.0, 2.0], 1)))
+y = 2 * x
+@. x = y
+@test all(all.(y .== x))


### PR DESCRIPTION
Attempt 2 to address https://github.com/SciML/OrdinaryDiffEq.jl/issues/2625#issuecomment-2720056747. I just applied the same approach taken in https://github.com/SciML/RecursiveArrayTools.jl/pull/425 for `setindex!` to broadcasted `Base.copyto!`.

I've verified that this also fixes the discrepancy in number of time-steps taken by an adaptive solver. The following MWE now results in the same number of accepted time-steps under this PR.
```julia
using OrdinaryDiffEqSSPRK, RecursiveArrayTools
using StaticArrays, StructArrays

function rhs!(du_voa, u_voa, params, t)
    du = parent(du_voa)
    u = parent(u_voa)
    du .= u
end

# StructArray storage
u = StructArray{SVector{1, Float64}}(ntuple(_ -> [1.0, 2.0], 1))
ode = ODEProblem(rhs!, VectorOfArray(u), (0, 0.7))
sol_SA = solve(ode, SSPRK43())
@show sol_SA.stats.naccept

# Vector{<:SVector} storage
u = SVector{1, Float64}.([1.0, 2.0])
ode = ODEProblem(rhs!, VectorOfArray(u), (0, 0.7))
sol_SV = solve(ode, SSPRK43())
@show sol_SV.stats.naccept
```