### PR TITLE
Make VectorOfArray adapt not broadcast the `to`

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -143,11 +143,11 @@ end
 Base.convert(::Type{AbstractArray}, VA::AbstractVectorOfArray) = stack(VA.u)
 
 function Adapt.adapt_structure(to, VA::AbstractVectorOfArray)
-    VectorOfArray(Adapt.adapt.(to, VA.u))
+    VectorOfArray(Adapt.adapt.((to,), VA.u))
 end
 
 function Adapt.adapt_structure(to, VA::AbstractDiffEqArray)
-    DiffEqArray(Adapt.adapt.(to, VA.u), Adapt.adapt(to, VA.t))
+    DiffEqArray(Adapt.adapt.((to,), VA.u), Adapt.adapt((to,), VA.t))
 end
 
 function VectorOfArray(vec::AbstractVector{T}, ::NTuple{N}) where {T, N}

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -147,7 +147,7 @@ function Adapt.adapt_structure(to, VA::AbstractVectorOfArray)
 end
 
 function Adapt.adapt_structure(to, VA::AbstractDiffEqArray)
-    DiffEqArray(Adapt.adapt.((to,), VA.u), Adapt.adapt((to,), VA.t))
+    DiffEqArray(Adapt.adapt.((to,), VA.u), Adapt.adapt(to, VA.t))
 end
 
 function VectorOfArray(vec::AbstractVector{T}, ::NTuple{N}) where {T, N}


### PR DESCRIPTION
Should fix https://buildkite.com/julialang/scimlsensitivity-dot-jl/builds/3324#0196626e-4fbc-4efa-887a-5d16f49ab679/459-1664