### PR TITLE
docs: add docstring for discretes support in `AbstractDiffEqArray`

### DIFF
--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -126,6 +126,9 @@ additional properties:
 An AbstractDiffEqArray adds the following fields:
 
 * `t` which holds the times of each timestep.
+* `discretes` (optional) which contains a
+  `SymbolicIndexingInterface.ParameterTimeseriesCollection` to allow storing and indexing
+  discrete variables. Indexing behavior is handled via `SymbolicIndexingInterface.getu`.
 """
 abstract type AbstractDiffEqArray{T, N, A} <: AbstractVectorOfArray{T, N, A} end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
