### PR TITLE
NamedArrayPartition zeromatrix

### DIFF
--- a/src/named_array_partition.jl
+++ b/src/named_array_partition.jl
@@ -145,6 +145,13 @@ end
     return dest
 end
 
+#Overwrite ArrayInterface zeromatrix to work with NamedArrayPartitions & implicit solvers within OrdinaryDiffEq
+function ArrayInterface.zeromatrix(A::NamedArrayPartition)
+	B = ArrayPartition(A)
+    x = reduce(vcat,vec.(B.x))
+    x .* x' .* false
+end
+
 # `x = find_NamedArrayPartition(x)` returns the first `NamedArrayPartition` among broadcast arguments.
 find_NamedArrayPartition(bc::Base.Broadcast.Broadcasted) = find_NamedArrayPartition(bc.args)
 function find_NamedArrayPartition(args::Tuple)

--- a/test/named_array_partition_tests.jl
+++ b/test/named_array_partition_tests.jl
@@ -9,10 +9,13 @@ using RecursiveArrayTools, Test
     @test x.a ≈ ones(10)
     @test typeof(x .+ x[1:end]) <: Vector # test broadcast precedence 
     @test all(x .== x[1:end])
+    @test ArrayInterface.zeromatrix(x) isa Matrix
+    @test size(ArrayInterface.zeromatrix(x)) == (30,30)
     y = copy(x)
     @test zero(x, (10, 20)) == zero(x) # test that ignoring dims works
     @test typeof(zero(x)) <: NamedArrayPartition
     @test (y .*= 2).a[1] ≈ 2 # test in-place bcast
+    
 
     @test length(Array(x)) == 30
     @test typeof(Array(x)) <: Array


### PR DESCRIPTION

New function implemented for ArrayInterface.zeromatrix for a NamedArrayPartition rather than an ArrayPartition in the style of commit 2094a78. Tests also implemented for both the return type and size of the zeromatrix. The implementation has been privately tested to work with OrdinaryDiffEq.jl and the implicit solvers that previously errored.
  
## Additional context

Created as a fix to https://github.com/SciML/OrdinaryDiffEq.jl/issues/2707
