### PR TITLE
Add KernelAbstractions.get_backend for VectorOfArray

### DIFF
--- a/ext/RecursiveArrayToolsKernelAbstractions.jl
+++ b/ext/RecursiveArrayToolsKernelAbstractions.jl
@@ -1,0 +1,16 @@
+module RecursiveArrayToolsKernelAbstractions
+
+import RecursiveArrayTools: VectorOfArray
+import KernelAbstractions
+
+
+function KernelAbstractions.get_backend(x::VectorOfArray)
+    u = parent(x)
+    if length(u) == 0
+        error("VectorOfArray is empty, cannot determine backend.")
+    end
+    # Use the backend of the first element in the parent array
+    return KernelAbstractions.get_backend(u[1])
+end
+
+end

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 
 [compat]
 CUDA = "3.12, 4, 5"

--- a/test/gpu/vectorofarray_gpu.jl
+++ b/test/gpu/vectorofarray_gpu.jl
@@ -1,4 +1,4 @@
-using RecursiveArrayTools, CUDA, Test, Zygote, Adapt
+using RecursiveArrayTools, CUDA, Test, Zygote, Adapt, KernelAbstractions
 CUDA.allowscalar(false)
 
 # Test indexing with colon
@@ -6,9 +6,13 @@ x = zeros(5)
 y = VectorOfArray([x, x, x])
 y[:, :]
 
+KernelAbstractions.get_backend(y) isa KernelAbstractions.CPU
+
 x = CUDA.zeros(5)
 y = VectorOfArray([x, x, x])
 y[:, :]
+
+KernelAbstractions.get_backend(y) isa CUDA.CUDABackend
 
 # Test indexing with boolean masks and colon
 nx, ny, nt = 3, 4, 5


### PR DESCRIPTION
**What feature report was addressed?**

In order to select where a KernelAbstractions kernel is launched it is helpful to be able to query the corresponding backend.
For `VectorOfArrays` this is a little bit weird since we likely care about where the "inner" arrays are being stored.

**Checklist**

- [] Appropriate tests were added
- [] The new feature was added in a way that does not break public API
- [] New documentation related to the new feature was added
- [] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).

**Additional context**

Add any other context about the problem here.
