### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/ext/RecursiveArrayToolsMeasurementsExt.jl
+++ b/ext/RecursiveArrayToolsMeasurementsExt.jl
@@ -1,7 +1,7 @@
 module RecursiveArrayToolsMeasurementsExt
 
 import RecursiveArrayTools
-isdefined(Base, :get_extension) ? (import Measurements) : (import ..Measurements)
+import Measurements
 
 function RecursiveArrayTools.recursive_unitless_bottom_eltype(a::Type{
         <:Measurements.Measurement,

--- a/ext/RecursiveArrayToolsMonteCarloMeasurementsExt.jl
+++ b/ext/RecursiveArrayToolsMonteCarloMeasurementsExt.jl
@@ -1,8 +1,7 @@
 module RecursiveArrayToolsMonteCarloMeasurementsExt
 
 import RecursiveArrayTools
-isdefined(Base, :get_extension) ? (import MonteCarloMeasurements) :
-(import ..MonteCarloMeasurements)
+import MonteCarloMeasurements
 
 function RecursiveArrayTools.recursive_unitless_bottom_eltype(a::Type{
         <:MonteCarloMeasurements.Particles,

--- a/ext/RecursiveArrayToolsTrackerExt.jl
+++ b/ext/RecursiveArrayToolsTrackerExt.jl
@@ -1,7 +1,7 @@
 module RecursiveArrayToolsTrackerExt
 
 import RecursiveArrayTools
-isdefined(Base, :get_extension) ? (import Tracker) : (import ..Tracker)
+import Tracker
 
 function RecursiveArrayTools.recursivecopy!(b::AbstractArray{T, N},
         a::AbstractArray{T2, N}) where {

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -2,7 +2,6 @@ module RecursiveArrayToolsZygoteExt
 
 using RecursiveArrayTools
 
-if isdefined(Base, :get_extension)
     using Zygote
     using Zygote: FillArrays, ChainRulesCore, literal_getproperty, @adjoint
 else


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks