### PR TITLE
Fix spelling errors

### DIFF
--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -36,8 +36,8 @@ An AbstractVectorOfArray subtype should match the following behaviors.
     plan in 2026 to complete the deprecation and thus have a breaking update where `A[i]`
     matches the linear indexing of an `AbstractArray`, and then making
     `AbstractVectorOfArray <: AbstractArray`. Until then, `AbstractVectorOfArray` due to
-    this interface break but manaully implements an AbstractArray-like interface for
-    future compatability.
+    this interface break but manually implements an AbstractArray-like interface for
+    future compatibility.
 
 ## Fields
 


### PR DESCRIPTION
Fix 2 spelling errors in documentation:
- manaully -> manually  
- compatability -> compatibility