### PR TITLE
Add `literal_getproperty` disptach for `VectorOfArray`

### DIFF
--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -99,7 +99,7 @@ end
     end
 end
 
-Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.VectorOfArray, ::Val{:u})
+Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.AbstractVectorOfArray, ::Val{:u})
     function literal_VectorOfArray_x_adjoint(d)
         m = map(enumerate(d)) do (idx, d_i)
             isnothing(d_i) && return zero(A.u[idx])

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -105,7 +105,7 @@ Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.Vecto
             isnothing(d_i) && return zero(A.u[idx])
             d_i
         end
-        (VectorOfArray(m),nothing)
+        (VectorOfArray(m), nothing)
     end
     A.u, literal_VectorOfArray_x_adjoint
 end

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -110,8 +110,8 @@ end
 function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractVectorOfArray)
     m = map(enumerate(d)) do (idx, d_i)
         isnothing(d_i) && return zero(A.u[idx])
-        d_i 
-    end 
+        d_i
+    end
     VectorOfArray(m)
 end
 

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -99,6 +99,17 @@ end
     end
 end
 
+Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.VectorOfArray, ::Val{:u})
+    function literal_VectorOfArray_x_adjoint(d)
+        m = map(enumerate(d)) do (idx, d_i)
+            isnothing(d_i) && return zero(A.u[idx])
+            d_i
+        end
+        (VectorOfArray(m),nothing)
+    end
+    A.u, literal_VectorOfArray_x_adjoint
+end
+
 @adjoint function literal_getproperty(A::ArrayPartition, ::Val{:x})
     function literal_ArrayPartition_x_adjoint(d)
         (ArrayPartition((isnothing(d[i]) ? zero(A.x[i]) : d[i] for i in 1:length(d))...),)

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -104,7 +104,7 @@ Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.Abstr
         dA = vofa_u_adjoint(d, A)
         (dA, nothing)
     end
-    A.u, literal_VectorOfArray_x_adjoint
+    A.u, literal_VectorOfArray_u_adjoint
 end
 
 function vofa_u_adjoint(d, A::RecursiveArrayTools.VectorOfArray)

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -107,7 +107,7 @@ Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.Abstr
     A.u, literal_AbstractVofA_u_adjoint
 end
 
-function vofa_u_adjoint(d, A::RecursiveArrayTools.VectorOfArray)
+function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractVectorOfArray)
     m = map(enumerate(d)) do (idx, d_i)
         isnothing(d_i) && return zero(A.u[idx])
         d_i 

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -100,14 +100,27 @@ end
 end
 
 Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.AbstractVectorOfArray, ::Val{:u})
-    function literal_VectorOfArray_x_adjoint(d)
-        m = map(enumerate(d)) do (idx, d_i)
-            isnothing(d_i) && return zero(A.u[idx])
-            d_i
-        end
-        (VectorOfArray(m), nothing)
+    function literal_AbstractVofA_u_adjoint(d)
+        dA = vofa_u_adjoint(d, A)
+        (dA, nothing)
     end
     A.u, literal_VectorOfArray_x_adjoint
+end
+
+function vofa_u_adjoint(d, A::RecursiveArrayTools.VectorOfArray)
+    m = map(enumerate(d)) do (idx, d_i)
+        isnothing(d_i) && return zero(A.u[idx])
+        d_i 
+    end 
+    VectorOfArray(m)
+end
+
+function vofa_u_adjoint(d, A::RecursiveArrayTools.DiffEqArray)
+    m = map(enumerate(d)) do (idx, d_i)
+        isnothing(d_i) && return zero(A.u[idx])
+        d_i
+    end
+    DiffEqArray(m, A.t)
 end
 
 @adjoint function literal_getproperty(A::ArrayPartition, ::Val{:x})

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -115,7 +115,7 @@ function vofa_u_adjoint(d, A::RecursiveArrayTools.VectorOfArray)
     VectorOfArray(m)
 end
 
-function vofa_u_adjoint(d, A::RecursiveArrayTools.DiffEqArray)
+function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractDiffEqArray)
     m = map(enumerate(d)) do (idx, d_i)
         isnothing(d_i) && return zero(A.u[idx])
         d_i

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -104,7 +104,7 @@ Zygote.@adjoint function Zygote.literal_getproperty(A::RecursiveArrayTools.Abstr
         dA = vofa_u_adjoint(d, A)
         (dA, nothing)
     end
-    A.u, literal_VectorOfArray_u_adjoint
+    A.u, literal_AbstractVofA_u_adjoint
 end
 
 function vofa_u_adjoint(d, A::RecursiveArrayTools.VectorOfArray)

--- a/test/adjoints.jl
+++ b/test/adjoints.jl
@@ -92,3 +92,9 @@ loss(x)
       VectorOfArray([collect((3i):(3i + 3)) for i in 1:5])
 @test Zygote.gradient(loss10, x)[1] == ForwardDiff.gradient(loss10, x)
 @test Zygote.gradient(loss11, x)[1] == ForwardDiff.gradient(loss11, x)
+
+voa = RecursiveArrayTools.VectorOfArray(fill(rand(3), 3))
+voa_gs, = Zygote.gradient(voa) do x
+    sum(sum.(x.u))
+end
+@test voa_gs isa RecursiveArrayTools.VectorOfArray


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Seen in some places surfacing as
```julia
ERROR: MethodError: no method matching size(::@NamedTuple{u::Vector{Vector{Float64}}})
The function `size` exists, but no method is defined for this combination of argument types.
You may need to implement the `length` method or define `IteratorSize` for this type to be `SizeUnknown`.

Closest candidates are:
  size(::IdentityOperator)
   @ SciMLOperators ~/.julia/packages/SciMLOperators/Gd0Qg/src/basic.jl:21
  size(::Graphs.DefaultDistance)
   @ Graphs ~/.julia/packages/Graphs/awp48/src/distance.jl:22
  size(::CSV.ReversedBuf)
   @ CSV ~/.julia/packages/CSV/XLcqT/src/utils.jl:569
  ...

Stacktrace:
  [1] (::RecursiveArrayToolsZygoteExt.var"#48#53")(y::@NamedTuple{u::Vector{Vector{Float64}}})
    @ RecursiveArrayToolsZygoteExt ~/.julia/packages/RecursiveArrayTools/EfvwE/ext/RecursiveArrayToolsZygoteExt.jl:79
  [2] (::RecursiveArrayToolsZygoteExt.var"#90#back#56"{RecursiveArrayToolsZygoteExt.var"#48#53"})(Δ::Base.RefValue{Any})
    @ RecursiveArrayToolsZygoteExt ~/.julia/packages/ZygoteRules/CkVIK/src/adjoint.jl:72
  [3] vecofvec
    @ ~/.julia/dev/DyadModelOptimizer/src/experiments/experiment_api.jl:163 [inlined]
  [4] replace_sol
    @ ~/.julia/dev/DyadModelOptimizer/src/experiments/experiment_api.jl:181 [inlined]
  [5] (::Zygote.Pullback{Tuple{…}, Tuple{…}})(Δ::Tuple{Base.RefValue{…}, Matrix{…}})
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface2.jl:0
  [6] replace_sol
    @ ~/.julia/dev/DyadModelOptimizer/src/experiments/experiment_api.jl:159 [inlined]
  [7] (::Zygote.Pullback{Tuple{…}, Tuple{…}})(Δ::Tuple{Base.RefValue{…}, Matrix{…}})
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface2.jl:0
  [8] compute_error
    @ ~/.julia/dev/DyadModelOptimizer/src/experiments/experiment_api.jl:200 [inlined]
  [9] (::Zygote.Pullback{Tuple{…}, Tuple{…}})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface2.jl:0
 [10] #cost_contribution#109
    @ ~/.julia/dev/DyadModelOptimizer/src/calibrate/multiple_shooting.jl:23 [inlined]
 [11] (::Zygote.Pullback{Tuple{…}, Any})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface2.jl:0
 [12] cost_contribution
    @ ~/.julia/dev/DyadModelOptimizer/src/calibrate/multiple_shooting.jl:14 [inlined]
 [13] (::Zygote.Pullback{Tuple{…}, Tuple{…}})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface2.jl:0
 [14] cost
    @ ~/.julia/dev/DyadModelOptimizer/src/objectives.jl:72 [inlined]
 [15] (::Zygote.Pullback{Tuple{DyadModelOptimizer.var"#cost#99"{…}, Vector{…}, Tuple{…}}, Any})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface2.jl:0
 [16] (::Zygote.var"#88#89"{Zygote.Pullback{Tuple{…}, Any}})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface.jl:97
 [17] gradient(::Function, ::Vector{Float64}, ::Vararg{Any})
    @ Zygote ~/.julia/packages/Zygote/55SqB/src/compiler/interface.jl:154
 [18] gradient
    @ ~/.julia/packages/DifferentiationInterface/D3LUI/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl:123 [inlined]
 [19] gradient!(f::Function, grad::Vector{…}, prep::DifferentiationInterface.NoGradientPrep{…}, backend::AutoZygote, x::Vector{…}, contexts::DifferentiationInterface.Constant{…})
    @ DifferentiationInterfaceZygoteExt ~/.julia/packages/DifferentiationInterface/D3LUI/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl:139
 [20] (::OptimizationZygoteExt.var"#grad#14"{…})(res::Vector{…}, θ::Vector{…})
    @ OptimizationZygoteExt ~/.julia/packages/OptimizationBase/Lc8sB/ext/OptimizationZygoteExt.jl:35
 [21] eval_objective_gradient(evaluator::OptimizationMOI.MOIOptimizationNLPEvaluator{…}, G::Vector{…}, x::Vector{…})
    @ OptimizationMOI ~/.julia/packages/OptimizationMOI/aKPgG/src/nlp.jl:259
 [22] eval_objective_gradient(model::IpoptMathOptInterfaceExt.Optimizer, grad::Vector{Float64}, x::Vector{Float64})
    @ IpoptMathOptInterfaceExt ~/.julia/packages/Ipopt/WfZ1b/ext/IpoptMathOptInterfaceExt/MOI_wrapper.jl:1163
 [23] (::IpoptMathOptInterfaceExt.var"#eval_grad_f_cb#8"{…})(x::Vector{…}, grad_f::Vector{…})
    @ IpoptMathOptInterfaceExt ~/.julia/packages/Ipopt/WfZ1b/ext/IpoptMathOptInterfaceExt/MOI_wrapper.jl:1372
 [24] _Eval_Grad_F_CB(n::Int32, x_ptr::Ptr{Float64}, ::Int32, grad_f::Ptr{Float64}, user_data::Ptr{Nothing})
    @ Ipopt ~/.julia/packages/Ipopt/WfZ1b/src/C_wrapper.jl:56
 [25] #5
    @ ~/.julia/packages/Ipopt/WfZ1b/src/C_wrapper.jl:407 [inlined]
 [26] disable_sigint(f::Ipopt.var"#5#6"{Ipopt.IpoptProblem, Base.RefValue{Float64}})
    @ Base ./c.jl:167
 [27] IpoptSolve
    @ ~/.julia/packages/Ipopt/WfZ1b/src/C_wrapper.jl:406 [inlined]
 [28] optimize!(model::IpoptMathOptInterfaceExt.Optimizer)
    @ IpoptMathOptInterfaceExt ~/.julia/packages/Ipopt/WfZ1b/ext/IpoptMathOptInterfaceExt/MOI_wrapper.jl:1526
 [29] optimize!(b::MathOptInterface.Bridges.LazyBridgeOptimizer{IpoptMathOptInterfaceExt.Optimizer})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/vK6dk/src/Bridges/bridge_optimizer.jl:367
 [30] __solve(cache::OptimizationMOI.MOIOptimizationNLPCache{…})
    @ OptimizationMOI ~/.julia/packages/OptimizationMOI/aKPgG/src/nlp.jl:550
 [31] solve!(cache::OptimizationMOI.MOIOptimizationNLPCache{…})
    @ SciMLBase ~/.julia/packages/SciMLBase/URv1y/src/solve.jl:234
 [32] solve(::OptimizationProblem{…}, ::MathOptInterface.OptimizerWithAttributes; kwargs::@Kwargs{…})
    @ SciMLBase ~/.julia/packages/SciMLBase/URv1y/src/solve.jl:131
 [33] macro expansion
    @ ./timing.jl:581 [inlined]
 [34] calibrate(prob::InverseProblem{…}, alg::SingleShooting{…}; adtype::AutoZygote, x0::Vector{…}, bounds::Tuple{…}, progress::Bool, parentid::Base.UUID, optimizer::MathOptInterface.OptimizerWithAttributes)
    @ DyadModelOptimizer ~/.julia/dev/DyadModelOptimizer/src/calibrate/calibrate.jl:38
 [35] top-level scope
    @ REPL[1]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

cc @SebastianM-C 


I am not a fan of adding a `literal_getproperty` dispatch but this can be a stopgap till we remove all similar ones at once.

Add any other context about the problem here.
