### PR TITLE
Move Statistics.jl to weak dependency extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [weakdeps]
@@ -22,6 +21,7 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
@@ -35,6 +35,7 @@ RecursiveArrayToolsMeasurementsExt = "Measurements"
 RecursiveArrayToolsMonteCarloMeasurementsExt = "MonteCarloMeasurements"
 RecursiveArrayToolsReverseDiffExt = ["ReverseDiff", "Zygote"]
 RecursiveArrayToolsSparseArraysExt = ["SparseArrays"]
+RecursiveArrayToolsStatisticsExt = "Statistics"
 RecursiveArrayToolsStructArraysExt = "StructArrays"
 RecursiveArrayToolsTablesExt = ["Tables"]
 RecursiveArrayToolsTrackerExt = "Tracker"
@@ -86,6 +87,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
@@ -93,4 +95,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "FastBroadcast", "ForwardDiff", "KernelAbstractions", "Measurements", "NLsolve", "Pkg", "Random", "SafeTestsets", "SciMLBase", "SparseArrays", "StaticArrays", "StructArrays", "Tables", "Test", "Unitful", "Zygote"]
+test = ["Aqua", "FastBroadcast", "ForwardDiff", "KernelAbstractions", "Measurements", "NLsolve", "Pkg", "Random", "SafeTestsets", "SciMLBase", "SparseArrays", "StaticArrays", "Statistics", "StructArrays", "Tables", "Test", "Unitful", "Zygote"]

--- a/ext/RecursiveArrayToolsStatisticsExt.jl
+++ b/ext/RecursiveArrayToolsStatisticsExt.jl
@@ -1,0 +1,15 @@
+module RecursiveArrayToolsStatisticsExt
+
+using RecursiveArrayTools
+using Statistics
+
+@inline Statistics.mean(VA::AbstractVectorOfArray; kwargs...) = mean(Array(VA); kwargs...)
+@inline function Statistics.median(VA::AbstractVectorOfArray; kwargs...)
+    median(Array(VA); kwargs...)
+end
+@inline Statistics.std(VA::AbstractVectorOfArray; kwargs...) = std(Array(VA); kwargs...)
+@inline Statistics.var(VA::AbstractVectorOfArray; kwargs...) = var(Array(VA); kwargs...)
+@inline Statistics.cov(VA::AbstractVectorOfArray; kwargs...) = cov(Array(VA); kwargs...)
+@inline Statistics.cor(VA::AbstractVectorOfArray; kwargs...) = cor(Array(VA); kwargs...)
+
+end

--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -5,7 +5,7 @@ $(DocStringExtensions.README)
 module RecursiveArrayTools
 
 using DocStringExtensions
-using RecipesBase, StaticArraysCore, Statistics,
+using RecipesBase, StaticArraysCore,
       ArrayInterface, LinearAlgebra
 using SymbolicIndexingInterface
 

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -861,14 +861,6 @@ end
     mapreduce(f, Base.mul_prod, VA; kwargs...)
 end
 
-@inline Statistics.mean(VA::AbstractVectorOfArray; kwargs...) = mean(Array(VA); kwargs...)
-@inline function Statistics.median(VA::AbstractVectorOfArray; kwargs...)
-    median(Array(VA); kwargs...)
-end
-@inline Statistics.std(VA::AbstractVectorOfArray; kwargs...) = std(Array(VA); kwargs...)
-@inline Statistics.var(VA::AbstractVectorOfArray; kwargs...) = var(Array(VA); kwargs...)
-@inline Statistics.cov(VA::AbstractVectorOfArray; kwargs...) = cov(Array(VA); kwargs...)
-@inline Statistics.cor(VA::AbstractVectorOfArray; kwargs...) = cor(Array(VA); kwargs...)
 @inline Base.adjoint(VA::AbstractVectorOfArray) = Adjoint(VA)
 
 # linear algebra


### PR DESCRIPTION
## Summary
- Moves Statistics.jl from a regular dependency to a weak dependency (extension)
- Reduces the base dependency footprint while maintaining full functionality

## Changes
- Moved Statistics from `[deps]` to `[weakdeps]` in Project.toml
- Created `RecursiveArrayToolsStatisticsExt` extension module
- Moved Statistics-dependent functions (`mean`, `median`, `std`, `var`, `cov`, `cor`) to the extension
- Added Statistics to test dependencies to ensure tests continue to work

## Testing
- Package compiles successfully
- Statistics functions work when Statistics.jl is loaded
- All existing functionality is preserved through the extension mechanism

This is part of a broader effort to reduce dependencies across the SciML stack by converting optional functionality to weak dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)