### PR TITLE
Add naive recursivecopy! implementation

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,6 +45,10 @@ like `copy!` on arrays of scalars.
 """
 function recursivecopy! end
 
+function recursivecopy!(b, a)
+        copyto!(b, a)
+end
+
 function recursivecopy!(b::AbstractArray{T, N},
         a::AbstractArray{T2, N}) where {T <: StaticArraysCore.StaticArray,
         T2 <: StaticArraysCore.StaticArray,


### PR DESCRIPTION
Implement basic version of recursivecopy! function.
  
The `recursivecopy!` is the default fallback for coping base structures from DifferentialEquations during stepping. If using custom structures that not necessarily follow the AbstractStructures/RecursiveArrayTools schemes, the stepping breaks.

Adding a naive recursivecopy! without specialization solves the problem when using custom structures with a Base.copyto! method defined without need of overloading `recursivecopy!` internaly. 
