### PR TITLE
Fix recursivefill! failure with immutable StaticArrays

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -826,7 +826,12 @@ end
 function Base.fill!(VA::AbstractVectorOfArray, x)
     for i in 1:length(VA.u)
         if VA[:, i] isa AbstractArray
-            fill!(VA[:, i], x)
+            if ArrayInterface.ismutable(VA.u[i]) || VA.u[i] isa AbstractVectorOfArray
+                fill!(VA[:, i], x)
+            else
+                # For immutable arrays like SVector, create a new filled array
+                VA.u[i] = fill(x, StaticArraysCore.similar_type(VA.u[i]))
+            end
         else
             VA[:, i] = x
         end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -139,6 +139,35 @@ end
     @test u1.u[2] isa SVector
 end
 
+# Test recursivefill! with immutable StaticArrays (issue #461)
+@testset "recursivefill! with immutable StaticArrays (issue #461)" begin
+    # Test with only immutable SVectors
+    x = VectorOfArray([SVector{2}(ones(2)), SVector{2}(ones(2))])
+    recursivefill!(x, 0.0)
+    @test all(x.u[i] == SVector{2}(zeros(2)) for i in 1:2)
+    @test all(x.u[i] isa SVector for i in 1:2)
+
+    # Test with mixed immutable and mutable StaticArrays
+    x = VectorOfArray([SVector{2}(ones(2)), MVector{2}(ones(2))])
+    recursivefill!(x, 0.0)
+    @test all(x.u[i] == [0.0, 0.0] for i in 1:2)
+    @test x.u[1] isa SVector
+    @test x.u[2] isa MVector
+
+    # Test fill! on VectorOfArray with immutable SVectors
+    x = VectorOfArray([SVector{2}(ones(2)), SVector{2}(ones(2))])
+    fill!(x, 0.0)
+    @test all(x.u[i] == SVector{2}(zeros(2)) for i in 1:2)
+    @test all(x.u[i] isa SVector for i in 1:2)
+
+    # Test fill! on VectorOfArray with mixed types
+    x = VectorOfArray([SVector{2}(ones(2)), MVector{2}(ones(2))])
+    fill!(x, 0.0)
+    @test all(x.u[i] == [0.0, 0.0] for i in 1:2)
+    @test x.u[1] isa SVector
+    @test x.u[2] isa MVector
+end
+
 import KernelAbstractions: get_backend
 @testset "KernelAbstractions" begin
     v = VectorOfArray([randn(2) for i in 1:10])


### PR DESCRIPTION
Fixes #461

## Summary
Fixes `recursivefill!` failure when called on a `VectorOfArray` containing immutable `StaticArray` types like `SVector`.

## Problem
The `recursivefill!` function failed when called on a `VectorOfArray` containing immutable static arrays. The underlying `Base.fill!` implementation attempted in-place modification of immutable arrays, which is not supported.

## Solution
Modified `Base.fill!` in `src/vector_of_array.jl` to check if each element array is mutable before attempting to fill it. For immutable arrays, we now create a new filled array using `StaticArraysCore.similar_type` and assign it.

## Changes
- Updated `Base.fill!` to handle both mutable and immutable arrays
- Added comprehensive tests for mixed StaticArray types

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>