### PR TITLE
Fix view of VectorOfArray with heterogeneous array sizes

### DIFF
--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -145,6 +145,31 @@ diffeq = DiffEqArray(recs, t)
 @test diffeq[:, 1] == recs[1]
 @test diffeq[1:2, 1:2] == [1 3; 2 5]
 
+# Test views of heterogeneous arrays (issue #453)
+f = VectorOfArray([[1.0], [2.0, 3.0]])
+@test length(view(f, :, 1)) == 1
+@test length(view(f, :, 2)) == 2
+@test view(f, :, 1) == [1.0]
+@test view(f, :, 2) == [2.0, 3.0]
+@test collect(view(f, :, 1)) == f[:, 1]
+@test collect(view(f, :, 2)) == f[:, 2]
+
+f2 = VectorOfArray([[1.0, 2.0], [3.0]])
+@test length(view(f2, :, 1)) == 2
+@test length(view(f2, :, 2)) == 1
+@test view(f2, :, 1) == [1.0, 2.0]
+@test view(f2, :, 2) == [3.0]
+@test collect(view(f2, :, 1)) == f2[:, 1]
+@test collect(view(f2, :, 2)) == f2[:, 2]
+
+# Test that views can be modified
+f3 = VectorOfArray([[1.0, 2.0], [3.0, 4.0, 5.0]])
+v = view(f3, :, 2)
+@test length(v) == 3
+v[1] = 10.0
+@test f3[1, 2] == 10.0
+@test f3.u[2][1] == 10.0
+
 t = 1:5
 recs = [rand(2, 2) for i in 1:5]
 testva = VectorOfArray(recs)


### PR DESCRIPTION
## Summary

Fixes #453 - `view(f, :, i)` for a VectorOfArray with heterogeneous inner array sizes now returns the correct result.

## Problem

Previously, when viewing a specific column of a VectorOfArray with differently sized inner arrays:
- `view(VectorOfArray([[1.0], [2.0, 3.0]]), :, 2)` returned a 1-element view instead of 2 elements
- `view(VectorOfArray([[1.0, 2.0], [3.0]]), :, 2)` returned a 2-element view with `#undef` instead of 1 element

The root cause was that `to_indices` uses `axes`, which is computed based on the first element's size. This doesn't work for heterogeneous arrays where different columns have different sizes.

## Solution

Added special handling for `view(A, :, i)` where `i` is an Int to use the actual size of the specific column being viewed rather than relying on `to_indices`.

## Changes

- Modified `Base.view` for `AbstractVectorOfArray` to handle heterogeneous arrays correctly
- Added comprehensive tests for views of heterogeneous arrays:
  - Testing correct lengths of views
  - Testing that views match regular indexing  
  - Testing that views can be modified

## Testing

All existing tests pass, plus new tests specifically for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>