### PR TITLE
Make RaggedEnd and RaggedRange broadcast as scalars

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -446,6 +446,10 @@ Base.:+(re::RaggedEnd, n::Integer) = RaggedEnd(re.dim, re.offset + Int(n))
 Base.:-(re::RaggedEnd, n::Integer) = RaggedEnd(re.dim, re.offset - Int(n))
 Base.:+(n::Integer, re::RaggedEnd) = re + n
 
+# Make RaggedEnd and RaggedRange broadcast as scalars to avoid
+# issues with collect/length in broadcasting contexts (e.g., SymbolicIndexingInterface)
+Base.broadcastable(x::RaggedEnd) = Ref(x)
+
 struct RaggedRange
     dim::Int
     start::Int
@@ -460,6 +464,7 @@ end
 function Base.:(:)(start::Integer, step::Integer, stop::RaggedEnd)
     RaggedRange(stop.dim, Int(start), Int(step), stop.offset)
 end
+Base.broadcastable(x::RaggedRange) = Ref(x)
 
 @inline function _is_ragged_dim(VA::AbstractVectorOfArray, d::Integer)
     length(VA.u) <= 1 && return false

--- a/test/basic_indexing.jl
+++ b/test/basic_indexing.jl
@@ -196,6 +196,20 @@ ragged2 = VectorOfArray([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0], [7.0, 8.0, 9.0]])
 @test ragged2[1:(end - 1), 2] == [5.0]
 @test ragged2[1:(end - 1), 3] == [7.0, 8.0]
 
+# Test that RaggedEnd and RaggedRange broadcast as scalars
+# (fixes issue with SymbolicIndexingInterface where broadcasting over RaggedEnd would fail)
+ragged_idx = lastindex(ragged, 1)
+@test ragged_idx isa RecursiveArrayTools.RaggedEnd
+@test Base.broadcastable(ragged_idx) isa Ref
+# Broadcasting with RaggedEnd should not error
+@test identity.(ragged_idx) === ragged_idx
+
+ragged_range_idx = 1:lastindex(ragged, 1)
+@test ragged_range_idx isa RecursiveArrayTools.RaggedRange
+@test Base.broadcastable(ragged_range_idx) isa Ref
+# Broadcasting with RaggedRange should not error
+@test identity.(ragged_range_idx) === ragged_range_idx
+
 # Broadcasting of heterogeneous arrays (issue #454)
 u = VectorOfArray([[1.0], [2.0, 3.0]])
 @test length(view(u, :, 1)) == 1
@@ -220,8 +234,8 @@ u[1, [1, 3], 2] .= [7.0, 9.0]
 
 # 3D inner arrays (tensors) with ragged third dimension
 u = VectorOfArray([zeros(2, 1, n) for n in (2, 3)])
-@test size(view(u,:,:,:,1)) == (2, 1, 2)
-@test size(view(u,:,:,:,2)) == (2, 1, 3)
+@test size(view(u, :, :, :, 1)) == (2, 1, 2)
+@test size(view(u, :, :, :, 2)) == (2, 1, 3)
 # assign into a slice of the second inner array using last index Int
 u[2, 1, :, 2] .= [7.0, 8.0, 9.0]
 @test vec(u.u[2][2, 1, :]) == [7.0, 8.0, 9.0]


### PR DESCRIPTION
## Summary

- Adds `Base.broadcastable(x::RaggedEnd) = Ref(x)` and `Base.broadcastable(x::RaggedRange) = Ref(x)` to make these types broadcast as scalars
- Adds tests verifying the broadcast behavior

## Problem

When using `end` indexing with ragged arrays in SymbolicIndexingInterface (e.g., `sol[x[1], end]`), broadcasting over `RaggedEnd` fails because Julia's broadcast machinery tries to `collect` it, which requires `length`:

```
MethodError: no method matching length(::RecursiveArrayTools.RaggedEnd)
```

Stack trace from ModelingToolkit CI:
```
[1] _similar_shape(itr::RecursiveArrayTools.RaggedEnd, ::Base.HasLength)
[2] _collect(cont::UnitRange{Int64}, itr::RecursiveArrayTools.RaggedEnd, ...)
[3] collect(itr::RecursiveArrayTools.RaggedEnd)
[4] broadcastable(x::RecursiveArrayTools.RaggedEnd)
```

## Solution

By defining `Base.broadcastable(x::RaggedEnd) = Ref(x)`, these types are now treated as scalars in broadcasting operations - similar to how `Symbol`, `String`, and other non-collection types work. This is semantically correct since `RaggedEnd` represents a single index value, not a collection.

## Test plan

- [x] Added tests verifying `RaggedEnd` and `RaggedRange` return `Ref` from `broadcastable`
- [x] Added tests verifying `identity.(ragged_idx)` works without error
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)