### PR TITLE
Add support for undef initializer in `ArrayPartition`

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -31,6 +31,15 @@ end
 @inline ArrayPartition(f::F, N) where {F <: Function} = ArrayPartition(ntuple(f, Val(N)))
 ArrayPartition(x...) = ArrayPartition((x...,))
 
+function (::Type{ArrayPartition{T, S}})(::UndefInitializer, n::Integer) where {T, S <: Tuple}
+    if length(S.parameters) != 1
+        throw(ArgumentError("ArrayPartition{T,S}(undef, n) is only supported for a single partition"))
+    end
+    part_type = S.parameters[1]
+    part = part_type(undef, n)
+    return ArrayPartition{T, S}((part,))
+end
+
 function ArrayPartition(x::S, ::Type{Val{copy_x}} = Val{false}) where {S <: Tuple, copy_x}
     T = promote_type(map(recursive_bottom_eltype, x)...)
     if copy_x

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -3,6 +3,15 @@ using RecursiveArrayTools, Test, Statistics, ArrayInterface, Adapt
 @test length(ArrayPartition()) == 0
 @test isempty(ArrayPartition())
 
+# Test undef initializer for single-partition ArrayPartition
+p_undef = ArrayPartition{Float64, Tuple{Vector{Float64}}}(undef, 10)
+@test p_undef isa ArrayPartition{Float64, Tuple{Vector{Float64}}}
+@test length(p_undef) == 10
+@test length(p_undef.x) == 1
+@test length(p_undef.x[1]) == 10
+# Test that multi-partition throws error
+@test_throws ArgumentError ArrayPartition{Float64, Tuple{Vector{Float64}, Vector{Float64}}}(undef, 10)
+
 A = (rand(5), rand(5))
 p = ArrayPartition(A)
 @inferred p[1]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Makes it possible to initialize an `ArrayPartition` with `undef`s if it only consists of one partition. This came up in https://github.com/NumericalMathematics/DispersiveShallowWater.jl/pull/207#issuecomment-2927463863. A more minimal example extracted from that PR is:

```julia
using LinearAlgebra, SparseArrays
using OrdinaryDiffEqSDIRK
using SciMLOperators
using RecursiveArrayTools

function rhs_explicit!(du, u, p, t)
    du .= u
end

n = 2
op = MatrixOperator(1.0 * sparse(I, n, n))
func = SplitFunction(op, rhs_explicit!)
u0 = ones(n)
u0 = ArrayPartition(u0)
prob = SplitODEProblem{true}(func, u0, (0.0, 1.0))
sol = solve(prob, KenCarp4(), saveat = 0.1)
```

Note that this MWE still fails at a later stage, but I guess this is something that would need to be fixed in LinearSolve.jl.