### PR TITLE
Fix zeromatrix to preserve GPU array types for ArrayPartition

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -548,7 +548,11 @@ end
 ## Linear Algebra
 
 function ArrayInterface.zeromatrix(A::ArrayPartition)
-    x = reduce(vcat, vec.(A.x))
+    # Use foldl with explicit init to preserve array type (important for GPU arrays)
+    # Starting with vec of first element ensures the result type matches the input
+    vecs = vec.(A.x)
+    rest = Base.tail(vecs)
+    x = isempty(rest) ? vecs[1] : foldl(vcat, rest; init = vecs[1])
     return x .* x' .* false
 end
 

--- a/src/named_array_partition.jl
+++ b/src/named_array_partition.jl
@@ -174,7 +174,10 @@ end
 #Overwrite ArrayInterface zeromatrix to work with NamedArrayPartitions & implicit solvers within OrdinaryDiffEq
 function ArrayInterface.zeromatrix(A::NamedArrayPartition)
     B = ArrayPartition(A)
-    x = reduce(vcat, vec.(B.x))
+    # Use foldl with explicit init to preserve array type (important for GPU arrays)
+    vecs = vec.(B.x)
+    rest = Base.tail(vecs)
+    x = isempty(rest) ? vecs[1] : foldl(vcat, rest; init = vecs[1])
     return x .* x' .* false
 end
 


### PR DESCRIPTION
## Summary

Fixes #496 - Solving ODE using ArrayPartition of GPUArrays fails for implicit solvers

The issue was that the `zeromatrix` function used `reduce(vcat, vec.(A.x))` which could cause type conversion issues with GPU arrays, leading to scalar indexing errors when using implicit ODE solvers with ArrayPartition containing CuArrays or MtlArrays.

### Changes

- Modified `ArrayInterface.zeromatrix(A::ArrayPartition)` to use `foldl` with an explicit `init` value from the first element, ensuring the result array type matches the input type
- Applied the same fix to `ArrayInterface.zeromatrix(A::NamedArrayPartition)`

### Root Cause

When `reduce(vcat, vec.(A.x))` was called with GPU arrays, the `reduce` operation could create an intermediate CPU array which then caused scalar indexing errors when OrdinaryDiffEq tried to build the Jacobian for implicit solvers.

The fix uses `foldl(vcat, rest; init = vecs[1])` which preserves the GPU array type by starting from the first GPU array element and concatenating subsequent elements onto it.

### Test Plan

- [x] All existing tests pass
- [x] Verified CPU arrays still work correctly with `zeromatrix`
- [x] Code formatted with Runic.jl

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)