### PR TITLE
Fix type instability for `vec[1, end]` indexing

### DIFF
--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -66,6 +66,18 @@ push!(testda, [-1, -2, -3, -4])
 @inferred sum(testva)
 @inferred sum(VectorOfArray([VectorOfArray([zeros(4, 4)])]))
 @inferred mapreduce(string, *, testva)
+# Type stability for `end` indexing (issue #525)
+testva_end = VectorOfArray([fill(2.0, 2) for i in 1:10])
+# Use lastindex directly since `end` doesn't work in SafeTestsets
+last_col = lastindex(testva_end, 2)
+@inferred testva_end[1, last_col]
+@test testva_end[1, last_col] == 2.0
+last_col = lastindex(testva_end)
+@inferred testva_end[1, last_col]
+@test testva_end[1, last_col] == 2.0
+last_row = lastindex(testva_end, 1)
+@inferred testva_end[last_row, 1]
+@test testva_end[last_row, 1] == 2.0
 
 # mapreduce
 testva = VectorOfArray([[1, 2, 3], [4, 5, 6], [7, 8, 9]])


### PR DESCRIPTION
## Summary
- Fixes #525
- Adds a specialized `getindex(A, i::Int, re::RaggedEnd)` method for type-stable access when using `end` indexing
- Adds a helper function `_ragged_getindex_int_col` as a function barrier for the Int column case
- Adds an early check in `_ragged_getindex` for the `RaggedEnd` sentinel case

## Problem
When accessing a `VectorOfArray` with `[1, end]`, the result was type-unstable (returning `Any`):
```julia
vecvec = VectorOfArray([fill(2.0, 2) for i in 1:10])
access_end(vec) = vec[1, end]
@code_warntype access_end(vecvec)  # Body::Any
```

The issue was that `lastindex(VA, d)` returns `RaggedEnd(0, offset)` as a sentinel for an already-resolved index, but the `getindex` dispatch couldn't infer the return type because `cols.dim == 0` is a runtime check.

## Solution
Add a specialized method for the common `vec[i, end]` pattern that handles the `RaggedEnd` type directly:
```julia
Base.@propagate_inbounds function Base.getindex(A::AbstractVectorOfArray, i::Int, re::RaggedEnd)
    if re.dim == 0
        return A.u[re.offset][i]
    else
        col = lastindex(A.u)
        resolved_idx = lastindex(A.u[col], re.dim) + re.offset
        return A.u[col][i, resolved_idx]
    end
end
```

After this fix:
```julia
@code_warntype access_end(vecvec)  # Body::Float64
```

## Test plan
- [x] Added test for type stability of `vec[1, end]` pattern
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)