### PR TITLE
Achieve type stability for indexing by avoiding variable boxing, including for ranges

### DIFF
--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -67,16 +67,19 @@ push!(testda, [-1, -2, -3, -4])
 @inferred sum(VectorOfArray([VectorOfArray([zeros(4, 4)])]))
 @inferred mapreduce(string, *, testva)
 # Type stability for `end` indexing (issue #525)
-testva_end = VectorOfArray([fill(2.0, 2) for i in 1:10])
+testva_end = VectorOfArray(fill(fill(2.0, 2), 10))
 # Use lastindex directly since `end` doesn't work in SafeTestsets
 last_col = lastindex(testva_end, 2)
 @inferred testva_end[1, last_col]
+@inferred testva_end[1, 1:last_col]
 @test testva_end[1, last_col] == 2.0
 last_col = lastindex(testva_end)
 @inferred testva_end[1, last_col]
+@inferred testva_end[1, 1:last_col]
 @test testva_end[1, last_col] == 2.0
 last_row = lastindex(testva_end, 1)
 @inferred testva_end[last_row, 1]
+@inferred testva_end[1:last_row, 1]
 @test testva_end[last_row, 1] == 2.0
 
 # mapreduce


### PR DESCRIPTION
## Checklist

- [X] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Following on from #525 , I realized that #526 _didn't_ fix anything for ranges e.g. `vec[1, 1:end]` (which is the indexing I actually used), and having taken a look at Cthulhu output I could tell something was off in the indexing since there were lots of boxed variables.

Eventually I worked out that the boxes were not due to closures, but due to variables being defined differently in different branches within the same scope. So I broke up the branches across a couple different functions, and that was enough to fix inference. 

I am not committed to the names of any of these functions necessarily, and there may be some other improvements possible to avoid repeating the same code (the AI generated a lot of repetitive code).


