### PR TITLE
Relax Zygote compat from 0.7.10 to 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -72,7 +72,7 @@ Tables = "1.12"
 Test = "1"
 Tracker = "0.2.34"
 Unitful = "1"
-Zygote = "0.7.10"
+Zygote = "0.7"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary
- Relaxes Zygote version constraint from `0.7.10` to `0.7`
- This allows any Zygote 0.7.x version to be used

## Rationale
There's a typo bug in Julia's base/meta.jl (line 412) where `spvals` is used instead of `static_param_values`. This bug causes an `UndefVarError: spvals not defined in Base.Meta` error when Zygote 0.7.10 is used to differentiate through functions that use `@cfunction` with type parameters (like Cubature.jl's integration routines).

By relaxing the constraint to allow Zygote 0.7.0-0.7.9, downstream packages like NeuralPDE.jl can work around this bug until Julia fixes the typo in base.

This is part of a series of PRs to relax Zygote constraints across the SciML ecosystem:
- SciMLBase.jl PR #1220 (merged)

🤖 Generated with [Claude Code](https://claude.ai/code)