### PR TITLE
Delete unnecessary `lastindex()` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.46.0"
+version = "3.46.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -280,7 +280,6 @@ end
 
 # Interface for the linear indexing. This is just a view of the underlying nested structure
 @inline Base.firstindex(A::ArrayPartition) = 1
-@inline Base.lastindex(A::ArrayPartition) = length(A)
 
 Base.@propagate_inbounds function Base.getindex(A::ArrayPartition, i::Int)
     @boundscheck checkbounds(A, i)

--- a/test/partitions_test.jl
+++ b/test/partitions_test.jl
@@ -135,6 +135,7 @@ y = ArrayPartition(ArrayPartition([1], [2.0]), ArrayPartition([3], [4.0]))
 # indexing
 @inferred first(x)
 @inferred last(x)
+@test lastindex(x) == length(x)
 
 # recursive
 @inferred recursive_mean(x)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fixes these invalidations when loaded through CurveFit.jl:
```julia
 inserting lastindex(A::RecursiveArrayTools.ArrayPartition) @ RecursiveArrayTools ~/.julia/packages/RecursiveArrayTools/otwou/src/array_partition.jl:283 invalidated:                                                                          
   backedges: 1: superseding lastindex(a::AbstractArray) @ Base abstractarray.jl:426 with MethodInstance for lastindex(::AbstractVector{UInt8}) (506 children)
```

Should not be necessary because of the Base implementation: https://github.com/JuliaLang/julia/blob/8f47b58ef511dd703e3eb9aeb37a668fe4403ca5/base/abstractarray.jl#L452