### PR TITLE
Run tests with JULIA_NUM_THREADS=2 so #570 regression test is covered

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,7 +18,11 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
+    name: "Tests - ${{ matrix.group }} - Julia ${{ matrix.version }}"
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -36,8 +40,31 @@ jobs:
         exclude:
           - version: "pre"
             group: "nopre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
-    secrets: "inherit"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "${{ matrix.version }}"
+      - uses: julia-actions/cache@v1
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          GROUP: "${{ matrix.group }}"
+          # Run tests with 2 threads so that threaded regression tests (e.g. the
+          # @.. thread=true VectorOfArray{SArray} test for issue #570) actually
+          # exercise FastBroadcast's Polyester-backed multi-thread batch-split
+          # path. With the default single thread, that path is a no-op and the
+          # regression is not covered. Mirrors SciML/OrdinaryDiffEq.jl's
+          # SublibraryCI.yml which passes JULIA_NUM_THREADS on the runtest step.
+          JULIA_NUM_THREADS: "2"
+      - uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: "src,ext"
+      - uses: codecov/codecov-action@v5
+        if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+        with:
+          files: lcov.info
+          token: "${{ secrets.CODECOV_TOKEN }}"
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary

- Issue #570 reported `@.. thread=true` on `VectorOfArray{SArray}` blew up on v4.0.1. PRs #564/#567 already fixed the dispatch path on master (base-ext `::Threaded` fallback → `Serial`, plus a Polyester ext for `<:AbstractVector{<:SArray}` storage), and master does handle Ranocha's reproducer correctly — verified locally against a `Pkg.develop`'d master.
- However, the regression testset added in #564 (`test/interface_tests.jl` `"Threaded @.. with VectorOfArray{SArray}"`) only triggers the failing code path when `Threads.nthreads() >= 2`. FastBroadcast's Polyester-backed threaded materialize splits work along the last axis via `view(dst, :, r)`; with a single thread that split is a no-op and the bad scalar `setindex!` loop is never reached.
- Previously `.github/workflows/Tests.yml` delegated to `SciML/.github/.github/workflows/tests.yml@v1`, which does not accept a thread-count input and does not set `JULIA_NUM_THREADS`, so CI ran with `Threads.nthreads() == 1` and the regression test silently passed without covering the bug.
- Inline the test job (dropping the reusable workflow) and set `JULIA_NUM_THREADS: "2"` as env on the `julia-actions/julia-runtest@v1` step. Mirrors `SciML/OrdinaryDiffEq.jl`'s `SublibraryCI.yml`, which passes `JULIA_NUM_THREADS: ${{ matrix.num_threads }}` the same way. No test-file changes needed.

## Root cause (for context, already fixed on master)

1. `@.. thread=true v = v + u` on `VectorOfArray{Float64,2,Matrix{SVector{2,Float64}}}` dispatches to `FastBroadcast.fast_materialize!(::Threaded, dst, bc)`.
2. On v4.0.1 there was no `::Threaded` method for `VectorOfArray` in the RAT extension, so dispatch fell through to the fully generic `FastBroadcast.jl:215` fallback → Polyester batches work by taking `view(dst, :, r)`, producing a `SubArray` wrapping the VoA.
3. Each batch then called FastBroadcast's generic `__fast_materialize!` scalar loop → `subview[i,j] = value` → `VectorOfArray.setindex!(VA, v, I::Int...)` at `src/vector_of_array.jl:904` → `VA.u[col][inner_I...] = v` → `setindex!(::SVector, …)` which throws on the immutable `SVector`.
4. #564/#567 added a base-ext `fast_materialize!(::Threaded, ::AbstractVectorOfArray, ::Broadcasted)` fallback that shunts to `Serial()`, avoiding the view-splitting path, plus a Polyester ext that genuinely threads `<:AbstractVector{<:SArray}` storage. The `Matrix{<:SArray}` case from Ranocha's reproducer still only runs serially (the type alias is `<:AbstractVector{<:SArray}`), but the fallback keeps it correct.

## Test plan

- [x] Local: ran `test/interface_tests.jl` with `JULIA_NUM_THREADS=2` against a `Pkg.develop`'d master → `Threaded @.. with VectorOfArray{SArray} | 2 pass`.
- [x] Local: ran Ranocha's exact reproducer from #570 under `JULIA_NUM_THREADS=2` against master → `v = [2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0]`; against `v4.0.1` the same reproducer still throws as reported.
- [ ] CI green on the existing `{version × group}` matrix, now with 2 threads per job.

## Follow-up (not in this PR)

- v4.0.1 itself is still broken for users; once this is merged and CI confirms the regression is genuinely exercised, a v4.0.2 patch release off master would close the user-visible side of #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
