### PR TITLE
Preserve container type in zero(VectorOfArray) via rewrap

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -945,7 +945,7 @@ end
 
 function Base.zero(VA::AbstractVectorOfArray)
     T = typeof(VA)
-    u_zero = [zero(u) for u in VA.u]
+    u_zero = rewrap(VA.u, [zero(u) for u in VA.u])
     fields = [fname == :u ? u_zero : _copyfield(VA, fname) for fname in fieldnames(T)]
     return T(fields...)
 end

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -131,3 +131,13 @@ x_immutablefv = [ImmutableFV(1.0, 2.0)]
 for vec in [x_staticvector, x_structarray, x_mutablefv, x_immutablefv]
     @test typeof(similar(VectorOfArray(vec))) === typeof(VectorOfArray(vec))
 end
+
+# Test that zero(VectorOfArray) preserves StructArray container type (via rewrap)
+let
+    sa = StructArray{SVector{2, Float64}}((Float64[1.0, 2.0], Float64[3.0, 4.0]))
+    voa = VectorOfArray(sa)
+    z = zero(voa)
+    @test z.u isa StructArray
+    @test all(iszero, z.u[1])
+    @test all(iszero, z.u[2])
+end


### PR DESCRIPTION
## Summary

`Base.zero(VA::AbstractVectorOfArray)` uses `[zero(u) for u in VA.u]` which always produces a plain `Vector`, even when `VA.u` is a `StructVector`. The constructor then fails:

```
MethodError: Cannot convert Vector{SVector{1,Float64}} to StructVector{...}
```

**Fix:** Wrap with `rewrap(VA.u, ...)` — same mechanism already used by broadcast. One-line change.

Fixes OrdinaryDiffEq.jl v7 CI (LowStorageRK/SSPRK StructArray compat tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)