### PR TITLE
fix(zygote ext): return struct-tangent cotangent from Array(::AbstractVectorOfArray)

### DIFF
--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -44,6 +44,8 @@ end
             # using linear indexing (which now returns scalar elements for VectorOfArray).
             if y isa AbstractVectorOfArray
                 (y.u,)
+            elseif y isa NamedTuple && haskey(y, :u)
+                (y.u,)
         else
                 (
                     [
@@ -67,6 +69,8 @@ end
                 y = VectorOfArray(y[].u)
         end
             if y isa AbstractVectorOfArray
+                (y.u, nothing)
+            elseif y isa NamedTuple && haskey(y, :u)
                 (y.u, nothing)
         else
                 (
@@ -113,11 +117,15 @@ end
 
 @adjoint function Base.Array(VA::AbstractVectorOfArray)
     adj = let VA = VA
-        function Array_adjoint(y)
-            # Return a VectorOfArray so it flows correctly back through VectorOfArray constructor
-            VA = recursivecopy(VA)
-            copyto!(VA, y)
-            return (VA,)
+        function Array_adjoint(y::AbstractArray{T, N}) where {T, N}
+            arrarr = [
+                [
+                    y[ntuple(_ -> Colon(), Val(N - 2))..., j, i]
+                    for j in 1:size(y)[end - 1]
+                ]
+                for i in 1:size(y)[end]
+            ]
+            return ((u = arrarr,),)
         end
     end
     Array(VA), adj

--- a/test/adjoints.jl
+++ b/test/adjoints.jl
@@ -90,3 +90,45 @@ voa_gs, = Zygote.gradient(voa) do x
     sum(sum.(x.u))
 end
 @test voa_gs isa RecursiveArrayTools.VectorOfArray
+
+@testset "Base.Array(::AbstractVectorOfArray) cotangent shape" begin
+    let voa = VectorOfArray([Float64.(1:3), Float64.(4:6), Float64.(7:9)])
+        y = Array(voa)
+        @test size(y) == (3, 3)
+        _, back = Zygote.pullback(Base.Array, voa)
+        cot, = back(ones(Float64, size(y)))
+        @test cot isa NamedTuple
+        @test haskey(cot, :u)
+        @test length(cot.u) == length(voa.u)
+        for i in eachindex(voa.u)
+            @test cot.u[i] == ones(Float64, length(voa.u[i]))
+        end
+    end
+
+    let ntraj = 4, ntime = 5, nstate = 2
+        voa = VectorOfArray([
+            VectorOfArray([Float64.((j - 1) * nstate .+ (1:nstate)) .+ (i - 0.5)
+                           for j in 1:ntime])
+            for i in 1:ntraj
+        ])
+        y = Array(voa)
+        @test size(y) == (nstate, ntime, ntraj)
+        _, back = Zygote.pullback(Base.Array, voa)
+        cot, = back(reshape(collect(Float64, 1:length(y)), size(y)))
+        @test cot isa NamedTuple
+        @test length(cot.u) == ntraj
+        for i in 1:ntraj
+            @test length(cot.u[i]) == ntime
+            @test all(length(v) == nstate for v in cot.u[i])
+        end
+    end
+end
+
+@testset "Array(::VectorOfArray) gradient matches ForwardDiff" begin
+    function row_loss(x)
+        voa = VectorOfArray([x .* i for i in 1:5])
+        sum(abs2, 1.0 .- Array(voa))
+    end
+    x = collect(Float64, 1:5)
+    @test Zygote.gradient(row_loss, x)[1] == ForwardDiff.gradient(row_loss, x)
+end


### PR DESCRIPTION
## Summary

The current `@adjoint Base.Array(VA::AbstractVectorOfArray)` reshapes the flat-array cotangent `y` back into the AbstractVectorOfArray's `.u` layout by `copyto!`'ing into a `recursivecopy(VA)` and returning that as the cotangent — i.e. the cotangent is the same AbstractVectorOfArray subtype as the original `VA`.

Under AbstractVectorOfArray's flat scalar `getindex`, downstream Zygote pullbacks that walk the cotangent by row index then receive the i-th *scalar* of the underlying linear layout instead of the i-th row. This breaks chains like:

- `SciMLBase.EnsembleSolution` constructor pullback iterating the per-trajectory tangents
- `DiffEqGPU.batch_solve`'s comprehension that builds per-trajectory `ODESolution`s from `solus[i]`

The chain either drops gradient information silently or — in the EnsembleGPUArray reverse-mode AD path — fails deeper with `DimensionMismatch: array with ndims(x) == 1 > 0 cannot have dx::Number` or `Need an adjoint for constructor`.

This PR returns a NamedTuple `(u = arrarr,)` struct tangent matching the AbstractVectorOfArray field layout. The downstream `VectorOfArray(u)` and `DiffEqArray(u, t)` constructor adjoints are extended to accept that NamedTuple and forward `y.u`.

## What this fixes downstream

End-to-end, this is layer 1 of a multi-layer chain that needs to land for reverse-mode AD through `EnsembleGPUArray` to work. With this fix in place plus matching SciMLBase fixes (separate PR coming), Zygote.gradient flows further through the chain (and surfaces the next issues, which I'm tracking separately).

## Tests

Added in `test/adjoints.jl`:

- **Direct shape assertions** on the cotangent for both 2D and 3D AbstractVectorOfArray layouts — confirms the returned cotangent is a NamedTuple (not the same wrapper type) and that `.u[i]` recovers per-row tangents of the right shape.
- **End-to-end Zygote-vs-ForwardDiff parity** on a loss that walks the row layout (this is the chain pattern the EnsembleGPUArray adjoint exercises).

All pre-existing adjoint tests continue to pass.

Please ignore until reviewed by @ChrisRackauckas.

## Test plan

- [ ] Existing `test/adjoints.jl` continues to pass
- [ ] New cotangent-shape testset passes
- [ ] New ForwardDiff-parity test passes