### PR TITLE
Apply Runic formatting to mooncake.jl and named_array_partition_tests.jl

### DIFF
--- a/test/mooncake.jl
+++ b/test/mooncake.jl
@@ -14,7 +14,7 @@ using RecursiveArrayTools, Mooncake, Test
 
 @testset "ArrayPartition increment_and_get_rdata!" begin
     @test Base.get_extension(RecursiveArrayTools, :RecursiveArrayToolsMooncakeExt) !==
-          nothing
+        nothing
 
     # Tangent produced by an upstream ChainRule.
     t = ArrayPartition([1.0, 2.0], [3.0, 4.0])

--- a/test/named_array_partition_tests.jl
+++ b/test/named_array_partition_tests.jl
@@ -58,21 +58,21 @@ end
     @test x[[1, 2]] == [1.0, 1.0]
     @test x[[1, 4]] == [1.0, 2.0]
 
-    @test x[1:2]    isa Vector{Float64}
-    @test x[1:end]  isa Vector{Float64}
+    @test x[1:2] isa Vector{Float64}
+    @test x[1:end] isa Vector{Float64}
     @test x[[1, 4]] isa Vector{Float64}
 
     # Inferred return types: Vector, not Union
-    @test (@inferred x[1:2])           isa Vector{Float64}
-    @test (@inferred x[1:length(x)])   isa Vector{Float64}
-    @test (@inferred x[[1, 4]])        isa Vector{Float64}
+    @test (@inferred x[1:2]) isa Vector{Float64}
+    @test (@inferred x[1:length(x)]) isa Vector{Float64}
+    @test (@inferred x[[1, 4]]) isa Vector{Float64}
 
     # `similar` with a non-matching dims falls back to the backing array;
     # with matching dims keeps the NamedArrayPartition wrapper.
     @test similar(x, Float64, (2,)) isa Vector{Float64}
-    @test similar(x, (2,))          isa Vector{Float64}
+    @test similar(x, (2,)) isa Vector{Float64}
     @test similar(x, Float64, size(x)) isa NamedArrayPartition
-    @test similar(x, size(x))          isa NamedArrayPartition
+    @test similar(x, size(x)) isa NamedArrayPartition
 
     # Scalar indexing untouched and type-stable
     @test x[1] == 1.0


### PR DESCRIPTION
## Summary
Fixes the FormatCheck workflow on `master`. Two whitespace-only fixes applied by `Runic.format_file(...; inplace = true)` with Runic v1.7:

- `test/mooncake.jl`: multi-line `@test` continuation indent
- `test/named_array_partition_tests.jl`: drop extra horizontal alignment spaces in `@test x[...]    isa Vector{...}` lines

Verified locally with `Runic.main(["--check", "--diff", ...])` exit code 0.

**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Test plan
- [ ] FormatCheck CI passes on this PR