### PR TITLE
Bump downstream OrdinaryDiffEq/MTK compat for RAT 4.x

### DIFF
--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -14,10 +14,10 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ArrayInterface = "7"
-ModelingToolkit = "8.33, 9"
+ModelingToolkit = "8.33, 9, 10, 11"
 MonteCarloMeasurements = "1.1"
 NLsolve = "4"
-OrdinaryDiffEq = "6.31"
+OrdinaryDiffEq = "6.31, 7"
 StaticArrays = "1"
 SymbolicIndexingInterface = "0.3"
 Tables = "1"


### PR DESCRIPTION
## Summary
Restores `Tests - Downstream` to green. Master has been red on Downstream Julia 1/lts/pre for weeks; this PR makes the resolver succeed *and* updates the downstream sources for the OrdinaryDiffEq 7 API the bump exposes.

### Compat changes (`test/downstream/Project.toml`)
- `OrdinaryDiffEq = "6.31"` → `"6.31, 7"`
- `ModelingToolkit = "8.33, 9"` → `"8.33, 9, 10, 11"` (OrdinaryDiffEq 7 transitively wants MTK 10+)
- Add `OrdinaryDiffEqRosenbrock = "1, 2"` (no longer re-exported from OrdinaryDiffEq)
- Add `RecursiveArrayToolsShorthandConstructors` (used by the `AP[...]` shorthand introduced in 334bd95)

### Why the resolver was unsatisfiable on master
- `Adapt = "4"` (required by RAT 4.x) narrows OrdinaryDiffEq to `[4.0.0 - 5.39.1, 6.64.0 - 7.0.0]`.
- OrdinaryDiffEq 6.110+ pins `RecursiveArrayTools = "3.52.0 - 3"`.
- Intersection in the 6.x window is empty, so OrdinaryDiffEq 7 is the only viable path.

### Downstream source fixes (exposed once the resolver succeeds)
- `Rosenbrock23(autodiff = false)` → `Rosenbrock23(autodiff = AutoFiniteDiff())`. OrdinaryDiffEq 7 rejects `Bool` and asks for an ADType.
- Add `using OrdinaryDiffEqRosenbrock` to `odesolve.jl` (provides `Rodas5`).
- Add `using RecursiveArrayToolsShorthandConstructors` to `odesolve.jl` and `downstream_events.jl` (needed for `AP[...]`).
- `SciMLBase.successful_retcode(sol)` → unqualified `successful_retcode(sol)`. `SciMLBase` is not a bare binding via `using OrdinaryDiffEq`, but `successful_retcode` and `AutoFiniteDiff` are — so we avoid adding `SciMLBase`/`ADTypes` as direct deps, which would unresolvably conflict with RAT 4.3's transitive SciMLBase 3 requirement.

### After (this branch)
```
Test Summary: | Pass  Broken  Total     Time
ODE Solve     |    4       1      5  1m34.7s
Test Summary: | Total  Time
Events        |     0  2.4s
Test Summary:          | Broken  Total  Time
Measurements and Units |      1      1  4.2s
Test Summary: | Pass  Total  Time
TrackerExt    |    1      1  0.5s
```

### Out of scope
- `test/downstream/symbol_indexing.jl` (run in the `SymbolicIndexingInterface` group) still has many failures, almost certainly from MTK 11 / SymbolicIndexingInterface API changes around symbolic-array indexing. Worth its own investigation — not gating this PR.
- `test/downstream/adjoints.jl` remains commented out in `runtests.jl` per the pre-existing `# TODO: re-enable after SciMLBase compat bump for RAT v4` note.

## Test plan
- [x] Resolution succeeds on Julia 1.11 (`Pkg.activate` + `Pkg.develop` + `Pkg.instantiate` for `test/downstream`)
- [x] `ODE Solve Tests` safetestset passes locally (4 pass, 1 pre-existing broken)
- [x] `Event Tests with ArrayPartition` safetestset runs without error
- [x] `Measurements and Units` safetestset passes (1 pre-existing broken)
- [x] `TrackerExt` safetestset passes (1 pass)
- [ ] CI on SciML/RecursiveArrayTools.jl Tests - Downstream - Julia 1/lts/pre