### PR TITLE
Fix sum(::AbstractVectorOfArray) over-constraining the element type (#595)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -106,4 +106,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "FastBroadcast", "ForwardDiff", "KernelAbstractions", "Measurements", "Mooncake", "NLsolve", "Pkg", "Polyester", "Random", "SafeTestsets", "SparseArrays", "StaticArrays", "Statistics", "StructArrays", "Tables", "Test", "Unitful", "Zygote"]
+test = ["Aqua", "FastBroadcast", "ForwardDiff", "KernelAbstractions", "Measurements", "Mooncake", "NLsolve", "Pkg", "Polyester", "Random", "ReverseDiff", "SafeTestsets", "SparseArrays", "StaticArrays", "Statistics", "StructArrays", "Tables", "Test", "Unitful", "Zygote"]

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -1137,10 +1137,14 @@ vecarr_to_vectors(VA::AbstractVectorOfArray) = [VA[i, :] for i in eachindex(VA.u
 # linear algebra
 ArrayInterface.issingular(va::AbstractVectorOfArray) = ArrayInterface.issingular(Matrix(va))
 
-# Type-stable sum/mapreduce that avoids inference issues on Julia 1.10
-# with deeply nested VectorOfArray type parameters
+# The `::` assertion pins the return type so Julia 1.10's inference does not bail
+# (widening to `Any`) on the self-recursion of `sum(::AbstractVectorOfArray)` for
+# deeply nested VectorOfArrays. It must be the type `sum` actually produces -- the
+# `add_sum` accumulator type -- and NOT the element type `T`, which over-constrains
+# the result for promoting eltypes (`Int8` -> `Int64`) and for AD scalars whose
+# summation drops metadata (e.g. `ReverseDiff.TrackedReal` origin); see issue #595.
 function Base.sum(VA::AbstractVectorOfArray{T}) where {T}
-    return sum(sum, VA.u)::T
+    return sum(sum, VA.u)::Base.promote_op(Base.add_sum, T, T)
 end
 
 function Base.sum(f::F, VA::AbstractVectorOfArray{T}) where {F, T}

--- a/test/adjoints.jl
+++ b/test/adjoints.jl
@@ -1,4 +1,4 @@
-using RecursiveArrayTools, Zygote, ForwardDiff, Test
+using RecursiveArrayTools, Zygote, ForwardDiff, ReverseDiff, Test
 
 function loss(x)
     return sum(abs2, Array(VectorOfArray([x .* i for i in 1:5])))
@@ -90,3 +90,12 @@ voa_gs, = Zygote.gradient(voa) do x
     sum(sum.(x.u))
 end
 @test voa_gs isa RecursiveArrayTools.VectorOfArray
+
+# issue #595: `sum(::VectorOfArray)` must not assert the element type, which
+# discarded ReverseDiff's `TrackedReal` origin and threw a `TypeError`.
+let g = ReverseDiff.gradient(x -> sum(VectorOfArray([x])), float.(1:3))
+    @test g ≈ ones(3)
+end
+let g = ReverseDiff.gradient(x -> sum(VectorOfArray([VectorOfArray([x])])), float.(1:3))
+    @test g ≈ ones(3)
+end

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -70,6 +70,13 @@ push!(testda, [-1, -2, -3, -4])
 @inferred sum(testva)
 @inferred sum(VA[VA[zeros(4, 4)]])
 @inferred mapreduce(string, *, testva)
+
+# sum must follow Base's promotion, not the element type (issue #595):
+# `Int8` elements sum to `Int64`, so asserting the result is `::Int8` is wrong.
+@test sum(VA[Int8[1, 2, 3]]) === Int64(6)
+@test sum(VA[Int8[1, 2], Int8[3, 4]]) === Int64(10)
+@test sum(VA[Float32[1, 2, 3]]) === 6.0f0
+@inferred sum(VA[Int8[1, 2, 3]])
 # Type stability for `end` indexing (issue #525)
 testva_end = VectorOfArray(fill(fill(2.0, 2), 10))
 # Use lastindex directly since `end` doesn't work in SafeTestsets


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Fixes #595.

## Problem

`sum(::AbstractVectorOfArray)` was defined as:

```julia
function Base.sum(VA::AbstractVectorOfArray{T}) where {T}
    return sum(sum, VA.u)::T
end
```

The `::T` assertion forces the result to equal the recursive element type `T`. That is wrong whenever summation does not return the element type:

- **The reported ReverseDiff failure.** For `VectorOfArray([tunables])` under `ReverseDiff.gradient`, `T = TrackedReal{Float64,Float64,<:TrackedArray}` — each element carries its *origin* `TrackedArray` in the third type parameter. A computed sum, however, is a fresh `TrackedReal{Float64,Float64,Nothing}` (no origin), so the assertion throws:

  ```
  TypeError: in typeassert, expected ReverseDiff.TrackedReal{Float64, Float64, ReverseDiff.TrackedArray{…}},
  got a value of type ReverseDiff.TrackedReal{Float64, Float64, Nothing}
  ```

- **It is not AD-specific.** `sum(VectorOfArray([Int8[1,2,3]]))` also throws `TypeError: expected Int8, got a value of type Int64` — ordinary integer promotion (`Int8 → Int64`) trips the same assertion.

## Why the assertion existed

It was added in 69798c3 to stop Julia 1.10 LTS inference from widening the *self-recursive* `sum(::AbstractVectorOfArray)` (a `VectorOfArray` may contain `VectorOfArray`s) to `Any`, which is what `@inferred sum(VA[VA[zeros(4,4)]])` guards against. Simply deleting `::T` restores correctness but reintroduces that inference regression (verified: the nested case infers `Any` again).

## Fix

Assert the type `sum` *actually* produces — the `Base.add_sum` accumulator type — instead of the element type:

```julia
function Base.sum(VA::AbstractVectorOfArray{T}) where {T}
    return sum(sum, VA.u)::Base.promote_op(Base.add_sum, T, T)
end
```

`add_sum` is the exact reduction operator `Base.sum` uses, so `promote_op(add_sum, T, T)` is `Int64` for `Int8`, `Float64` for `Float64`, and `TrackedReal{…,Nothing}` for ReverseDiff. `promote_op` is computed by inference over the scalar eltype (no VoA recursion), so it still pins the return type and keeps `@inferred` green on the LTS, while being correct for promoting and AD eltypes. If inference cannot determine `add_sum(::T,::T)` it returns `Any`, degrading gracefully to a no-op assertion (never wrong).

## Tests

- `test/interface_tests.jl`: `Int8`/`Float32` promotion (`sum(VA[Int8[1,2,3]]) === Int64(6)`, …) plus `@inferred`.
- `test/adjoints.jl`: the ReverseDiff MWE from the issue (single- and nested-VoA gradients). `ReverseDiff` added to the test target (it is already a `[weakdeps]`/compat entry).

Verified locally on **Julia 1.10.11, 1.11.9, 1.12.6, and 1.13.0-rc1** — all correctness and inference checks pass. Real test files pass: Partitions 115/115, Interface 139/139, Adjoint 13/13. Runic check is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)