### PR TITLE
CI: make coverage upload and cache save non-fatal

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -63,7 +63,11 @@ jobs:
           end
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
+        # Coverage upload is a reporting step; an upload failure (e.g. the empty
+        # CODECOV_TOKEN on fork PRs, rate limits, codecov outages) must not fail a
+        # green downstream test job.
+        continue-on-error: true
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/GPU.yml
+++ b/.github/workflows/GPU.yml
@@ -32,6 +32,9 @@ jobs:
           GROUP: "GPU"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
+        # `fail_ci_if_error: false` is not enough: the action still exits non-zero
+        # when the token is empty (e.g. fork PRs), so guard the step itself.
+        continue-on-error: true
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           version: "${{ matrix.version }}"
       - uses: julia-actions/cache@v3
+        # The cache save (post) step fails to authenticate with the cache backend
+        # on some self-hosted runners; a cache miss must not fail an otherwise
+        # green test job.
+        continue-on-error: true
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: julia-actions/julia-buildpkg@v1
@@ -64,7 +68,10 @@ jobs:
           directories: "src,ext"
       - uses: codecov/codecov-action@v6
         if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+        # Coverage upload is a reporting step; an upload failure (token, rate
+        # limit, codecov outage) must not fail a green test job.
+        continue-on-error: true
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## Problem

Recent CI runs are broadly red, but the failures are almost entirely **infrastructure**, not test failures. Investigated by inspecting per-step conclusions on master `72fa309`:

| Job (on master HEAD) | Failing step | `julia-runtest` |
|---|---|---|
| `SciMLBase.jl/Core` | `codecov/codecov-action@v6` | ✅ passed |
| `DiffEqBase.jl/Core` | `codecov/codecov-action@v6` | ✅ passed |
| `OrdinaryDiffEq.jl/Core` | `codecov/codecov-action@v6` | ✅ passed |
| `DiffEqBase.jl/Downstream2` | `codecov/codecov-action@v6` | ✅ passed |
| `GPU Tests` | `codecov/codecov-action@v6` | ✅ passed |
| `Tests - nopre - Julia 1` | `Post Run julia-actions/cache@v3` | ✅ passed |

Two root causes:

1. **Codecov upload failing the job.** `codecov/codecov-action@v6` ran with `fail_ci_if_error: true` in `Tests.yml` and `Downstream.yml`, so any upload failure (token issues, rate limits, a codecov outage, or the empty `CODECOV_TOKEN` on fork PRs) failed the whole job after tests had already passed. `GPU.yml` already used `fail_ci_if_error: false` — this brings the others in line.
2. **Cache save failing the job.** `julia-actions/cache@v3`'s save (post) step fails to authenticate with the cache backend on some self-hosted runners (`Server failed to authenticate the request` / `ENOENT: …/cache.tzst`), failing the job after tests passed.

## Fix

Coverage upload and cache save are reporting/infrastructure steps; neither should turn a green test run red.

- `Tests.yml`, `Downstream.yml`: codecov → `fail_ci_if_error: false` + `continue-on-error: true`.
- `GPU.yml`: codecov → add `continue-on-error: true` (`fail_ci_if_error: false` alone is insufficient — the action still exits non-zero with an empty token, as seen on fork PRs).
- `Tests.yml`: `julia-actions/cache@v3` → `continue-on-error: true`.

**Test steps are untouched** — a real test failure still fails CI. This only stops infra/reporting steps from masquerading as test failures.

## Scope / not covered here

- `SciMLSensitivity.jl/Core6` fails in the *actual* test step (`Load this and run the downstream tests`), not codecov/cache — a genuine downstream failure that is independent of this change and needs separate triage.
- The `Documentation` job's coverage step lives in the reusable `SciML/.github/.github/workflows/documentation.yml@v1`, not this repo, so it is out of scope here.

YAML validated locally (parses; `continue-on-error`/`fail_ci_if_error` settings confirmed on every codecov/cache step). Cannot run GitHub Actions locally — the next CI run on this PR will confirm the infra steps no longer fail jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)