### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,23 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "RecursiveArrayTools, Pkg, TOML, Statistics, LinearAlgebra, SparseArrays, InteractiveUtils, Random, Test"
+      allow-reresolve: true


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What this does

Adds a centralized sublibrary downgrade CI workflow (`.github/workflows/DowngradeSublibraries.yml`) that calls the reusable `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1` workflow.

The reusable workflow auto-discovers every `lib/*` package containing a `Project.toml` and, for each one, runs `julia-downgrade-compat` + `julia-buildpkg` + `julia-runtest` on `project: lib/<sub>`. This ensures the lower bounds of each sublibrary's `[compat]` are actually installable and pass tests.

It runs on `push`/`pull_request` to `master` (ignoring `docs/**`), with concurrency cancellation on non-master refs.

## Sublibraries covered (3)

- `lib/RecursiveArrayToolsArrayPartitionAnyAll`
- `lib/RecursiveArrayToolsRaggedArrays`
- `lib/RecursiveArrayToolsShorthandConstructors`

All three contain a `test/runtests.jl`.

## skip list

Dependencies excluded from downgrade (in-repo core package + stdlibs):

`RecursiveArrayTools, Pkg, TOML, Statistics, LinearAlgebra, SparseArrays, InteractiveUtils, Random, Test`

`RecursiveArrayTools` is the root in-repo package that all three sublibraries depend on, so it should not be downgraded.

## Config

- `julia-version: "lts"`
- `allow-reresolve: true`
- No `projects`/`exclude` (auto-discover all `lib/*`).

## Note

This adds new required-looking status checks (one job per sublibrary). New checks will appear on PRs once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)