### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,25 +12,16 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: "Downgrade"
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,15 +7,10 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: SciMLBase.jl, group: Core}
           - {user: SciML, repo: DiffEqBase.jl, group: Core}
@@ -32,38 +27,10 @@ jobs:
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core5}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core6}
           - {user: SciML, repo: LabelledArrays.jl, group: RecursiveArrayTools}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+      julia-version: "1"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Centralize CI through SciML/.github reusable workflows (@v1)

This routes the repo's bespoke standard GitHub Actions workflows through the shared reusable workflows in `SciML/.github/.github/workflows/*.yml@v1`, preserving each workflow's existing matrices, triggers, and config. Pure YAML/git rewiring — no source changes.

### Converted workflows

| File | Now calls | Preserved config |
|------|-----------|------------------|
| `Downgrade.yml` | `downgrade.yml@v1` | `group: Core`, `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`; master push/PR triggers + `paths-ignore: docs/**` |
| `Downstream.yml` | `downstream.yml@v1` | Full SciML downstream package/group matrix (SciMLBase, DiffEqBase x3, DiffEqSensitivity, OrdinaryDiffEq x2, DelayDiffEq, SciMLSensitivity Core1-6, LabelledArrays); `julia-version: 1`; `IntegrationTest` name + triggers |
| `FormatCheck.yml` | `runic.yml@v1` | Runic format check; master/main/release- push + tags + PR triggers |
| `SpellCheck.yml` | `spellcheck.yml@v1` | `pull_request` trigger |

### Intentionally left bespoke (coverage cannot be faithfully expressed by a reusable)

- **`Tests.yml`** — sets `JULIA_NUM_THREADS: "2"` on the runtest step to exercise the threaded `FastBroadcast` / `VectorOfArray{SArray}` regression tests (issues #564 / #570) in `test/interface_tests.jl`. The reusable `tests.yml@v1` has no thread input, so converting it would silently run those tests single-threaded and drop the regression coverage. Per the centralization spec ("never lose coverage"), this workflow is left as-is.
- **`GPU.yml`** — targets a specific `[self-hosted, Linux, X64, gpu]` runner with `GROUP=GPU`. The reusable `self-hosted` input resolves to a bare `self-hosted` label and cannot target the GPU-labeled runner, so this is left local.
- **`Documentation.yml`** — already a thin caller of `documentation.yml@v1`; untouched.
- **`TagBot.yml`** — non-CI release automation (`JuliaRegistries/TagBot`); no reusable equivalent, left local.

### Monorepo / sublibrary handling

The repo has 3 sublibraries under `lib/` (`RecursiveArrayToolsArrayPartitionAnyAll`, `RecursiveArrayToolsRaggedArrays`, `RecursiveArrayToolsShorthandConstructors`), each with its own `Project.toml` + `test/`. However, there is **no per-sublibrary CI** (no `CI_*.yml`, no `SublibraryCI.yml`, no `DowngradeSublibraries.yml`). The sublibraries are tested as `GROUP`s of the main package's single `Tests.yml` (`RaggedArrays`, `ArrayPartitionAnyAll`, `ShorthandConstructors`), and none of them carry the `test/test_groups.toml` that `sublibrary-tests.yml@v1` auto-discovery requires. Introducing a `SublibraryCI.yml` here would discover nothing and would not replace the existing GROUP-based coverage, so **no sublibrary CI workflow was added** (N/A). Since `Tests.yml` is left bespoke for the threading reason above, its sublibrary GROUP coverage is preserved unchanged.

### NOTE: required-status-check names change

Converting to reusable workflows changes the **job names** that appear as status checks (e.g. the reusable emits `Tests / Downstream Tests - ...`, `Downgrade`, `Runic`, `Spell Check with Typos`). **Branch protection required-status-check names must be updated** accordingly, or required checks will report as missing.

---

Please ignore until reviewed by @ChrisRackauckas.
