### PR TITLE
ci: centralize Tests.yml (tests.yml@v1 with num-threads: 2)

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,11 +18,7 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests - ${{ matrix.group }} - Julia ${{ matrix.version }}"
-    permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
@@ -40,31 +36,10 @@ jobs:
         exclude:
           - version: "pre"
             group: "nopre"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: "${{ matrix.version }}"
-      - uses: julia-actions/cache@v3
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: "${{ matrix.group }}"
-          # Run tests with 2 threads so that threaded regression tests (e.g. the
-          # @.. thread=true VectorOfArray{SArray} test for issue #570) actually
-          # exercise FastBroadcast's Polyester-backed multi-thread batch-split
-          # path. With the default single thread, that path is a no-op and the
-          # regression is not covered. Mirrors SciML/OrdinaryDiffEq.jl's
-          # SublibraryCI.yml which passes JULIA_NUM_THREADS on the runtest step.
-          JULIA_NUM_THREADS: "2"
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: "src,ext"
-      - uses: codecov/codecov-action@v6
-        if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
-        with:
-          files: lcov.info
-          token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+      num-threads: "2"
+      coverage-directories: "src,ext"
+    secrets: "inherit"


### PR DESCRIPTION
Converts the bespoke `Tests.yml` to a `tests.yml@v1` caller, now possible since the reusable workflow gained a `num-threads` input (SciML/.github#43). Preserves the version×group matrix, **`num-threads: 2`** (issue #570 threaded regression coverage), and `coverage-directories: src,ext`. This was the last thing keeping RecursiveArrayTools on bespoke test CI.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)