### PR TITLE
fix: handle ZeroTangent/AbstractZero in RecursiveArrayToolsZygoteExt adjoint

### DIFF
--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -4,6 +4,7 @@ using RecursiveArrayTools
 
 using Zygote
 using Zygote: FillArrays, ChainRulesCore, literal_getproperty, @adjoint
+using Zygote.ChainRulesCore: AbstractZero
 
 function ChainRulesCore.rrule(
         T::Type{<:RecursiveArrayTools.GPUArraysCore.AbstractGPUArray},
@@ -90,7 +91,7 @@ end
 
 function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractVectorOfArray)
     m = map(enumerate(d)) do (idx, d_i)
-        isnothing(d_i) && return zero(A.u[idx])
+        (isnothing(d_i) || d_i isa AbstractZero) && return zero(A.u[idx])
         d_i
     end
     return VectorOfArray(m)
@@ -98,7 +99,7 @@ end
 
 function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractDiffEqArray)
     m = map(enumerate(d)) do (idx, d_i)
-        isnothing(d_i) && return zero(A.u[idx])
+        (isnothing(d_i) || d_i isa AbstractZero) && return zero(A.u[idx])
         d_i
     end
     return DiffEqArray(m, A.t)
@@ -106,7 +107,7 @@ end
 
 @adjoint function literal_getproperty(A::ArrayPartition, ::Val{:x})
     function literal_ArrayPartition_x_adjoint(d)
-        (ArrayPartition((isnothing(d[i]) ? zero(A.x[i]) : d[i] for i in 1:length(d))...),)
+        (ArrayPartition((isnothing(d[i]) || d[i] isa AbstractZero ? zero(A.x[i]) : d[i] for i in 1:length(d))...),)
     end
     A.x, literal_ArrayPartition_x_adjoint
 end

--- a/test/adjoints.jl
+++ b/test/adjoints.jl
@@ -1,4 +1,5 @@
 using RecursiveArrayTools, Zygote, ForwardDiff, ReverseDiff, Test
+using Zygote: ChainRulesCore
 
 function loss(x)
     return sum(abs2, Array(VectorOfArray([x .* i for i in 1:5])))
@@ -98,4 +99,22 @@ let g = ReverseDiff.gradient(x -> sum(VectorOfArray([x])), float.(1:3))
 end
 let g = ReverseDiff.gradient(x -> sum(VectorOfArray([VectorOfArray([x])])), float.(1:3))
     @test g ≈ ones(3)
+end
+
+# A `ZeroTangent`/`AbstractZero` slice in the cotangent (structural zero gradient)
+# must be treated like an absent gradient instead of erroring on `size(::ZeroTangent)`.
+let ext = Base.get_extension(RecursiveArrayTools, :RecursiveArrayToolsZygoteExt)
+    voa = VectorOfArray([Float64[i, i, i] for i in 1:3])
+    dea = DiffEqArray([Float64[i, i, i] for i in 1:3], 1:3)
+    d = Any[Float64[1, 1, 1], ChainRulesCore.ZeroTangent(), Float64[3, 3, 3]]
+    expected = [Float64[1, 1, 1], Float64[0, 0, 0], Float64[3, 3, 3]]
+
+    g_voa = ext.vofa_u_adjoint(d, voa)
+    @test g_voa isa VectorOfArray
+    @test g_voa.u == expected
+
+    g_dea = ext.vofa_u_adjoint(d, dea)
+    @test g_dea isa DiffEqArray
+    @test g_dea.u == expected
+    @test g_dea.t == dea.t
 end


### PR DESCRIPTION
## Problem

The Zygote pullbacks in `ext/RecursiveArrayToolsZygoteExt.jl` for `VectorOfArray`/`DiffEqArray` (`vofa_u_adjoint`) and `ArrayPartition` only special-cased `isnothing(d_i)` for missing per-slice gradients. When a cotangent element is a `ChainRulesCore.ZeroTangent` (an `AbstractZero`, a *structural* zero gradient), it was passed through unchanged. The subsequent `VectorOfArray`/`DiffEqArray` construction then calls `size(::ZeroTangent)`, throwing:

```
MethodError: no method matching size(::ChainRulesCore.ZeroTangent)
```

This breaks reverse-mode AD through `DiffEqArray(vec, ts)` and shows up downstream (e.g. DifferenceEquations.jl `test/linear_gradients.jl:67`).

## Fix

Treat `AbstractZero` the same as `nothing` in the adjoints: a structural zero gradient for that slice (skip reconstruction, propagate a real zero array). `AbstractZero` is imported from the already-available `ChainRulesCore`.

## Test

Added a focused regression test in `test/adjoints.jl` that feeds a `ZeroTangent` cotangent element through `vofa_u_adjoint` for both `VectorOfArray` and `DiffEqArray` and asserts the result is the correct zero gradient (and no longer errors). Verified the test fails on the unpatched code and passes with the fix.

Local run on Julia 1.10 (`test/adjoints.jl`): **PASS**.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)