### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,45 +18,7 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "lts"
-          - "1"
-          - "pre"
-        group:
-          - "Core"
-          - "QA"
-          - "SymbolicIndexingInterface"
-          - "Downstream"
-          - "NoPre"
-        exclude:
-          # JET (NoPre) is not run on prereleases.
-          - version: "pre"
-            group: "NoPre"
-          # QA (Aqua) runs only on lts and 1, never on prereleases.
-          - version: "pre"
-            group: "QA"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
-      num-threads: "2"
       check-bounds: "auto"
-      coverage-directories: "src,ext"
-    secrets: "inherit"
-
-  # GPU tests are a dep-adding group (test/GPU/Project.toml) that runs on the
-  # self-hosted GPU runner. Folded in from the former bespoke GPU.yml.
-  gpu:
-    name: "GPU Tests"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "1"
-      group: "GPU"
-      runner: '["self-hosted", "Linux", "X64", "gpu"]'
-      timeout-minutes: 60
-      coverage-directories: "src,ext"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,24 @@
+[Core]
+versions = ["lts", "1", "pre"]
+num_threads = 2
+
+[QA]
+versions = ["lts", "1"]
+num_threads = 2
+
+[SymbolicIndexingInterface]
+versions = ["lts", "1", "pre"]
+num_threads = 2
+
+[Downstream]
+versions = ["lts", "1", "pre"]
+num_threads = 2
+
+[NoPre]
+versions = ["lts", "1"]
+num_threads = 2
+
+[GPU]
+versions = ["1"]
+runner = ["self-hosted", "Linux", "X64", "gpu"]
+timeout = 60


### PR DESCRIPTION
## Summary

Converts the root package's CI test workflow (`.github/workflows/CI.yml`) from a hand-maintained `group × version` matrix (plus a bespoke `gpu` job) into the reusable `grouped-tests.yml@v1` thin caller. The matrix is now declared once in `test/test_groups.toml` and computed by `compute_affected_sublibraries.jl --root-matrix`.

The sublibrary workflow (`SublibraryCI.yml`, which calls `sublibrary-project-tests.yml@v1`) is left untouched.

## Changes

- **`.github/workflows/CI.yml`**: the `tests` + `gpu` matrix jobs become a single thin caller. `name: CI`, the `on:` triggers, and `concurrency:` are preserved verbatim so the branch-protection status check name is unchanged. `check-bounds: "auto"` is carried as a workflow-level `with:` input (non-default). `coverage-directories` is left at the `src,ext` default (matches the old value).
- **`test/test_groups.toml`** (new): reproduces the old matrix exactly.
  - `Core`, `SymbolicIndexingInterface`, `Downstream`: `["lts", "1", "pre"]`, `num_threads = 2`
  - `QA`, `NoPre`: `["lts", "1"]` (the old `exclude:` dropped these on `pre`), `num_threads = 2`
  - `GPU`: version `["1"]`, `runner = ["self-hosted", "Linux", "X64", "gpu"]`, `timeout = 60` (folded in from the old `gpu` job)

The root `test/runtests.jl` dispatches on the default `GROUP` env var, so no `group-env-name` override is needed.

## Verification

Ran `compute_affected_sublibraries.jl . --root-matrix` and confirmed the emitted `(group, version, runner)` set equals the old workflow's set exactly: **14/14, no missing, no extra**. TOML and all workflow YAML files parse cleanly. The package test suite was not run locally (CI validates it).

Ignore until reviewed by @ChrisRackauckas.