### PR TITLE
Add QA (Aqua/JET) groups to sublibraries (SciML/.github#77)

### DIFF
--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
@@ -9,11 +9,14 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 RecursiveArrayTools = {path = "../.."}
 
 [compat]
+Pkg = "1"
 RecursiveArrayTools = "4"
+Test = "1"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "Test"]

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+RecursiveArrayToolsArrayPartitionAnyAll = "172d604e-c495-4f00-97bf-d70957099afa"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+RecursiveArrayToolsArrayPartitionAnyAll = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+RecursiveArrayToolsArrayPartitionAnyAll = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/qa.jl
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using RecursiveArrayToolsArrayPartitionAnyAll, Aqua, JET, Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(RecursiveArrayToolsArrayPartitionAnyAll)
+    end
+    @testset "JET" begin
+        JET.test_package(RecursiveArrayToolsArrayPartitionAnyAll; target_defined_modules = true)
+    end
+end

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/runtests.jl
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/runtests.jl
@@ -1,6 +1,27 @@
 using RecursiveArrayTools, RecursiveArrayToolsArrayPartitionAnyAll, Test
+using Pkg
 
 const TEST_GROUP = get(ENV, "RECURSIVEARRAYTOOLS_TEST_GROUP", "Core")
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11, the [sources] section in the qa Project.toml is not
+    # honored, so Pkg.develop the local paths explicitly.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                PackageSpec(path = dirname(@__DIR__)),
+                PackageSpec(path = normpath(joinpath(dirname(@__DIR__), "..", ".."))),
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    include("qa/qa.jl")
+end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @testset "Optimized any" begin

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/test_groups.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -17,15 +17,19 @@ RecursiveArrayTools = {path = "../.."}
 Adapt = "4"
 ArrayInterface = "7.17.0"
 LinearAlgebra = "1.10"
+Pkg = "1"
 RecursiveArrayTools = "4"
+SparseArrays = "1.10"
 StaticArraysCore = "1.4.2"
 SymbolicIndexingInterface = "0.3.42"
+Test = "1"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SparseArrays", "SymbolicIndexingInterface", "Test"]
+test = ["Pkg", "SparseArrays", "SymbolicIndexingInterface", "Test"]

--- a/lib/RecursiveArrayToolsRaggedArrays/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+RecursiveArrayToolsRaggedArrays = "c384ba91-639a-44ca-823a-e1d3691ab84a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+RecursiveArrayToolsRaggedArrays = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+RecursiveArrayToolsRaggedArrays = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/RecursiveArrayToolsRaggedArrays/test/qa/qa.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using RecursiveArrayToolsRaggedArrays, Aqua, JET, Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(RecursiveArrayToolsRaggedArrays)
+    end
+    @testset "JET" begin
+        JET.test_package(RecursiveArrayToolsRaggedArrays; target_defined_modules = true)
+    end
+end

--- a/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
@@ -3,8 +3,29 @@ using RecursiveArrayToolsRaggedArrays: RaggedEnd, RaggedRange
 using SymbolicIndexingInterface
 using SymbolicIndexingInterface: SymbolCache
 using Test
+using Pkg
 
 const TEST_GROUP = get(ENV, "RECURSIVEARRAYTOOLS_TEST_GROUP", "Core")
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11, the [sources] section in the qa Project.toml is not
+    # honored, so Pkg.develop the local paths explicitly.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                PackageSpec(path = dirname(@__DIR__)),
+                PackageSpec(path = normpath(joinpath(dirname(@__DIR__), "..", ".."))),
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    include("qa/qa.jl")
+end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @testset "RecursiveArrayToolsRaggedArrays" begin

--- a/lib/RecursiveArrayToolsRaggedArrays/test/test_groups.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
@@ -9,11 +9,14 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 RecursiveArrayTools = {path = "../.."}
 
 [compat]
+Pkg = "1"
 RecursiveArrayTools = "4"
+Test = "1"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "Test"]

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+RecursiveArrayToolsShorthandConstructors = "39fb7555-b4ad-4efd-8abe-30331df017d3"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+RecursiveArrayToolsShorthandConstructors = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+RecursiveArrayToolsShorthandConstructors = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/qa/qa.jl
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using RecursiveArrayToolsShorthandConstructors, Aqua, JET, Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(RecursiveArrayToolsShorthandConstructors)
+    end
+    @testset "JET" begin
+        JET.test_package(RecursiveArrayToolsShorthandConstructors; target_defined_modules = true)
+    end
+end

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/runtests.jl
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/runtests.jl
@@ -1,6 +1,27 @@
 using RecursiveArrayTools, RecursiveArrayToolsShorthandConstructors, Test
+using Pkg
 
 const TEST_GROUP = get(ENV, "RECURSIVEARRAYTOOLS_TEST_GROUP", "Core")
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11, the [sources] section in the qa Project.toml is not
+    # honored, so Pkg.develop the local paths explicitly.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                PackageSpec(path = dirname(@__DIR__)),
+                PackageSpec(path = normpath(joinpath(dirname(@__DIR__), "..", ".."))),
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    include("qa/qa.jl")
+end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @testset "VA[...] shorthand" begin

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/test_groups.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Part of SciML/.github#77 — canonical QA (Aqua + JET) groups for monorepo sublibraries.

## Units in this batch

- `lib/RecursiveArrayToolsArrayPartitionAnyAll`
- `lib/RecursiveArrayToolsRaggedArrays`
- `lib/RecursiveArrayToolsShorthandConstructors`

## What each unit gets

- `test/qa/Project.toml`: isolated QA env with Aqua + JET + Test and the sublibrary via `[sources]` path (compat: julia 1.10, Aqua 0.8, JET 0.9/0.10/0.11, Test 1).
- `test/qa/qa.jl`: `Aqua.test_all` + `JET.test_package(...; target_defined_modules = true)`.
- QA dispatch in `test/runtests.jl` gated on `RECURSIVEARRAYTOOLS_TEST_GROUP == "QA"`, activating the qa env with the same Julia < 1.11 `[sources]`-develop fallback the root QA env uses (develops both the sublibrary and the umbrella root so LTS tests PR-branch code).
- `Pkg` added to `[extras]`/`[targets]` with a `[compat]` entry; missing compat entries for existing extras (`Test`, `SparseArrays`) added so `Aqua.test_deps_compat` stays green.
- `[QA]` group in `test/test_groups.toml` with `versions = ["lts", "1"]` (no `pre`, ubuntu-only), picked up by the centralized `sublibrary-project-tests.yml` matrix.

Verification was static only (TOML parse, `Meta.parseall` on runtests/qa.jl, `[sources]` path resolution, extras-compat coverage); QA findings will be triaged from CI per the established mark-broken+issue policy.

Further batches may be pushed to this branch. Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)