### PR TITLE
Fix sublibrary QA Aqua piracy via treat_as_own for owned types

### DIFF
--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/qa.jl
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/qa.jl
@@ -1,8 +1,12 @@
 using RecursiveArrayToolsArrayPartitionAnyAll, Aqua, JET, Test
 
+const RATAPAA = RecursiveArrayToolsArrayPartitionAnyAll
+
 @testset "QA" begin
     @testset "Aqua" begin
-        Aqua.test_all(RecursiveArrayToolsArrayPartitionAnyAll)
+        # `any`/`all` are extended on the RecursiveArrayTools-owned `ArrayPartition`
+        # type, so they are intentional (owned) methods, not piracy.
+        Aqua.test_all(RATAPAA; piracies = (; treat_as_own = [RATAPAA.ArrayPartition]))
     end
     @testset "JET" begin
         JET.test_package(RecursiveArrayToolsArrayPartitionAnyAll; target_defined_modules = true)

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/qa/qa.jl
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/qa/qa.jl
@@ -1,8 +1,13 @@
 using RecursiveArrayToolsShorthandConstructors, Aqua, JET, Test
 
+const RATSC = RecursiveArrayToolsShorthandConstructors
+
 @testset "QA" begin
     @testset "Aqua" begin
-        Aqua.test_all(RecursiveArrayToolsShorthandConstructors)
+        # `getindex(::Type{VA}, ...)` / `getindex(::Type{AP}, ...)` extend Base on
+        # RecursiveArrayTools-owned types, so they are intentional (owned) methods,
+        # not piracy.
+        Aqua.test_all(RATSC; piracies = (; treat_as_own = [RATSC.VA, RATSC.AP]))
     end
     @testset "JET" begin
         JET.test_package(RecursiveArrayToolsShorthandConstructors; target_defined_modules = true)


### PR DESCRIPTION
## Problem

The sublibrary `QA` groups added in #614 currently fail on `master` for two of the three sublibraries. The Aqua `Piracy` test reports the sublibraries' methods as type piracy:

- **RecursiveArrayToolsArrayPartitionAnyAll** — `any`/`all` extended on `ArrayPartition`
- **RecursiveArrayToolsShorthandConstructors** — `getindex(::Type{VA}, xs...)` and `getindex(::Type{AP}, xs...)`

These are not piracy: `ArrayPartition`, `VA`, and `AP` are types **owned by `RecursiveArrayTools`**, which each sublibrary hard-depends on. Extending `Base` functions on a dependency's owned types is the intended design of these subpackages (it is the entire reason they exist, as documented in their module docstrings).

## Fix

Pass the owned types through Aqua's documented `treat_as_own` mechanism:

```julia
Aqua.test_all(RATAPAA; piracies = (; treat_as_own = [RATAPAA.ArrayPartition]))
Aqua.test_all(RATSC;   piracies = (; treat_as_own = [RATSC.VA, RATSC.AP]))
```

No package source changes; only the QA test configuration is corrected.

## Local verification (Julia 1.10, the package's `[compat]` floor)

Ran the full `test/qa/qa.jl` (Aqua + JET) for each sublibrary against the in-tree source:

```
ArrayPartitionAnyAll  QA | Pass 12  Total 12
ShorthandConstructors QA | Pass 12  Total 12
```

Both groups now pass entirely (Aqua piracy included, JET unaffected).

## Out of scope (reported separately)

- **RecursiveArrayToolsRaggedArrays QA** also fails Aqua piracy (same owned-type pattern) **and** has genuine JET inference findings (`no matching method found similar_type(::Any)` in `copyto!`/`fill!`/broadcast, because the ragged container's `.u` field is `Any`-typed). The JET findings are real and would require type-stabilizing the ragged container, so RaggedArrays is intentionally left out of this focused PR.
- **Downgrade (Core)** fails with an `Unsatisfiable` resolver error at the `--min=@deps --julia=1.10` downgrade minimum — a compat-floor conflict, separate from this QA issue.

Please ignore until reviewed by @ChrisRackauckas.
