### PR TITLE
fix(zygote ext): handle NamedTuple cotangents in vofa_u_adjoint (EnsembleSolution end-time grads)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.3.2"
+version = "4.3.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/RecursiveArrayToolsZygoteExt.jl
+++ b/ext/RecursiveArrayToolsZygoteExt.jl
@@ -94,6 +94,7 @@ function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractVectorOfArray)
         (isnothing(d_i) || d_i isa AbstractZero) && return zero(A.u[idx])
         d_i
     end
+    _vofa_cotangent_array(m) || return m
     return VectorOfArray(m)
 end
 
@@ -102,7 +103,17 @@ function vofa_u_adjoint(d, A::RecursiveArrayTools.AbstractDiffEqArray)
         (isnothing(d_i) || d_i isa AbstractZero) && return zero(A.u[idx])
         d_i
     end
+    _vofa_cotangent_array(m) || return m
     return DiffEqArray(m, A.t)
+end
+
+# Whether the per-element cotangents can be rewrapped in a `VectorOfArray`/`DiffEqArray`.
+# When they are structural tangents instead (e.g. `NamedTuple`s for the solution
+# objects in an `EnsembleSolution`, produced when only a scalar field such as
+# `sol.t[end]` is differentiated) they have no `ndims`, so the cotangent is passed
+# through as a plain vector rather than erroring. (DifferentialEquations.jl#1149)
+function _vofa_cotangent_array(m)
+    return all(x -> x isa Union{AbstractArray, AbstractVectorOfArray}, m)
 end
 
 @adjoint function literal_getproperty(A::ArrayPartition, ::Val{:x})

--- a/test/AD/adjoints.jl
+++ b/test/AD/adjoints.jl
@@ -118,3 +118,27 @@ let ext = Base.get_extension(RecursiveArrayTools, :RecursiveArrayToolsZygoteExt)
     @test g_dea.u == expected
     @test g_dea.t == dea.t
 end
+
+# Structural `NamedTuple` cotangents (e.g. the per-trajectory solution cotangents
+# of an `EnsembleSolution` when only a scalar field such as `sol.t[end]` is
+# differentiated) cannot be wrapped in a `VectorOfArray`/`DiffEqArray`; they must
+# pass through as a plain vector instead of erroring on `ndims(::NamedTuple)`.
+# (DifferentialEquations.jl#1149)
+let ext = Base.get_extension(RecursiveArrayTools, :RecursiveArrayToolsZygoteExt)
+    voa = VectorOfArray([Float64[i, i, i] for i in 1:3])
+    dea = DiffEqArray([Float64[i, i, i] for i in 1:3], 1:3)
+    d = [(u = nothing, t = Float64[0, 0, i]) for i in 1:3]
+
+    g_voa = ext.vofa_u_adjoint(d, voa)
+    @test g_voa == d
+
+    g_dea = ext.vofa_u_adjoint(d, dea)
+    @test g_dea == d
+
+    # `nothing`/`AbstractZero` slices still drop out even when mixed with structural tangents.
+    d_mixed = Any[
+        (u = nothing, t = Float64[0, 0, 1]), nothing,
+        ChainRulesCore.ZeroTangent(),
+    ]
+    @test ext.vofa_u_adjoint(d_mixed, voa)[1] == d_mixed[1]
+end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## What this PR is (and is not)

This is a **local robustness fix** in the Zygote extension: `vofa_u_adjoint` must not force structural (`NamedTuple`) cotangents into a `VectorOfArray`/`DiffEqArray` — that reconstruction calls `ndims(::NamedTuple)`, which has no method. Structural per-element cotangents now pass through as a plain vector.

**This does NOT fix SciML/DifferentialEquations.jl#1149.** End-to-end verification (below) shows the failure merely moves downstream, and the underlying capability (reverse-mode gradients w.r.t. `sol.t`, e.g. `terminate!` halting times) does not exist in the adjoint path at all.

## Original symptom

Zygote through an `EnsembleSolution` when the loss reads only a scalar field per trajectory:

```julia
T_stars = [sol.t[end] for sol in ensemble_sol.u]   # halting times via terminate! callback
```

```
ERROR: MethodError: no method matching ndims(::@NamedTuple{…})
  [1] RecursiveArrayTools.VectorOfArray(vec::Vector{@NamedTuple{…}})
  [2] vofa_u_adjoint(...)
```

Each per-trajectory cotangent is a structural `NamedTuple` (`(u = nothing, t = OneElement(...), …)`), not an array, because only `sol.t[end]` is differentiated. This is the structural-tangent sibling of the `ZeroTangent` case fixed in #606 (same function).

## End-to-end verification of the full issue MRE (Julia 1.11.9, OrdinaryDiffEq v7.1.1, SciMLBase v3.31.0, SciMLSensitivity v7.113.0, Zygote v0.7.11)

With this patch, the `ndims` crash is gone and the `NamedTuple` cotangents (carrying the real `t::ChainRules.OneElement` seed) flow through. The failure then relocates to SciMLBase:

```
ERROR: BoundsError: attempt to access Tuple{Int64} at index [0]
  [5] EnsembleSolution_adjoint(p̄::Vector{@NamedTuple{u::Nothing, …, t::OneElement{…}, …}})
    @ SciMLBaseZygoteExt ~/.julia/packages/SciMLBase/V1DOE/ext/SciMLBaseZygoteExt.jl:83
```

(the generic `p̄::AbstractArray{T,N}` method assumes `N ≥ 2`; a `Vector{NamedTuple}` matches it with `N = 1` since `NamedTuple` is not `<:AbstractArray`).

**More importantly, fixing that plumbing would produce silently wrong gradients.** `Δ.t` is consumed nowhere in SciMLSensitivity — the backpass only reads `Δ.u`. Verified on a minimal single-trajectory case (no ensemble, no RAT in the loop), `loss(θ) = sol.t[end]` with `GaussAdjoint(ReverseDiffVJP())` + `terminate!`:

```
ForwardDiff: ‖∇‖ = 0.536
Zygote:      ‖∇‖ = 0.0     (adjoint runs, t-cotangent silently discarded, no error)
```

So the pre-existing state for the non-ensemble version of this loss is a **silent zero gradient**, which is arguably a worse bug than the crash reported in the issue.

## Consequences

- The real fix for SciML/DifferentialEquations.jl#1149 belongs in SciMLSensitivity: either implement event-time adjoint corrections (IFT at the callback root, per arXiv 2011.03902), or at minimum throw an informative error when a nonzero `t` cotangent reaches an adjoint sensealg instead of silently dropping it.
- SciMLBase's `EnsembleSolution_adjoint` needs a method for vectors of structural tangents (guarded by the same "don't silently drop `t`" consideration).
- This PR remains correct and useful on its own terms: array-wrapping structural tangents is a type error regardless of what downstream does, and the #606 guard was incomplete without it.

## Test

Added to `test/AD/adjoints.jl`, mirroring the #606 test: `NamedTuple` cotangents through `vofa_u_adjoint` for both `VectorOfArray` and `DiffEqArray`, plus a mixed `NamedTuple`/`nothing`/`ZeroTangent` case. Verified locally: the new test reproduces the exact `ndims(::NamedTuple)` error on unmodified source and passes with the fix; full `AD/adjoints.jl` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
