### PR TITLE
Allow CUDA.jl v6 in GPU test environment

### DIFF
--- a/test/GPU/Project.toml
+++ b/test/GPU/Project.toml
@@ -15,7 +15,7 @@ RecursiveArrayToolsArrayPartitionAnyAll = {path = "../../lib/RecursiveArrayTools
 [compat]
 Adapt = "4"
 ArrayInterface = "7.17.0"
-CUDA = "3.12, 4, 5"
+CUDA = "6"
 KernelAbstractions = "0.9.36"
 RecursiveArrayTools = "4"
 RecursiveArrayToolsArrayPartitionAnyAll = "1"


### PR DESCRIPTION
## Summary

The GPU test environment pins CUDA.jl to `"3.12, 4, 5"`. The V100 GPU CI runners now run nvidia driver 580, which requires CUDA.jl **v6.2+** — versions below 6.2 select the CUDA runtime based on the driver version and pick an incompatible runtime, causing GPU CI to fail. The fix landed in [JuliaGPU/CUDA.jl#3134](https://github.com/JuliaGPU/CUDA.jl/pull/3134) (see also [issue #3079](https://github.com/JuliaGPU/CUDA.jl/issues/3079)).

This widens the CUDA compat in the GPU test environment to `"6"` so the resolver picks the latest 6.x (currently ≥6.2), which contains the runtime-selection fix.

## Changes

- Bump `CUDA` compat from `"3.12, 4, 5"` to `"6"` in `test/GPU/Project.toml`.

Test-environment-only; the package `Project.toml` compat (already `"5, 6.0"`) and version are unaffected.
