### PR TITLE
Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.3.2"
+version = "4.3.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -60,7 +60,7 @@ KernelAbstractions = "0.9.36"
 LinearAlgebra = "1.10"
 Measurements = "2.11"
 MonteCarloMeasurements = "1.2"
-Mooncake = "0.5"
+Mooncake = "0.5.36"
 Pkg = "1"
 Polyester = "0.7.16"
 PrecompileTools = "1.2.1"

--- a/test/AD/Project.toml
+++ b/test/AD/Project.toml
@@ -11,7 +11,7 @@ RecursiveArrayTools = {path = "../.."}
 
 [compat]
 ForwardDiff = "0.10.38, 1"
-Mooncake = "0.5"
+Mooncake = "0.5.36"
 RecursiveArrayTools = "4"
 ReverseDiff = "1.15"
 Test = "1"


### PR DESCRIPTION
Raise the Mooncake `[compat]` floor to the latest Mooncake release (`0.5.36`) in every Project.toml that declares a Mooncake compat entry, so the Downgrade lane stops pinning an ancient Mooncake.

## Raised floors

| File | Old floor | New floor |
|------|-----------|-----------|
| `Project.toml` (root, weakdep) | `Mooncake = "0.5"` | `Mooncake = "0.5.36"` |
| `test/AD/Project.toml` (hard dep) | `Mooncake = "0.5"` | `Mooncake = "0.5.36"` |

Root package version bumped `4.3.2` -> `4.3.3` (a `[compat]` narrowing on a weakdep is a patch-level change). `test/AD/Project.toml` is a test env with no `version` field, so nothing to bump there.

## Why

The old `"0.5"` floor let the Downgrade min-resolution pin **Mooncake 0.5.0** (verified below), the oldest 0.5.x, which drags in stale/incompatible transitive deps. Pinning a single floor at the latest keeps the downgrade lane on a modern Mooncake.

## Verification (resolves_at_min)

Ran `julia-actions/julia-downgrade-compat@v2` (v2.5.2 — the version pinned by `SciML/.github` `downgrade.yml@v1`) on **Julia 1.12**, min mode (`--min=@deps`):

- **`test/AD` (Mooncake hard dep): resolves_at_min = true.** Resolution succeeds; Mooncake pins to exactly **0.5.36** (ForwardDiff 0.10.38, ReverseDiff 1.15.0, Zygote 0.7.0 all at their floors). With the old `"0.5"` floor the same resolve pinned Mooncake **0.5.0**.
- **Root `.` Core downgrade: resolves.** In `deps` mode `downgrade-compat@v2` does not promote weakdeps, so Mooncake stays a weakdep and is excluded from the root merged resolution; the root resolves cleanly.

No `Unsatisfiable` on this repo with `downgrade-compat@v2`. The floor-raise is the correct "limit to latest Mooncake" fix, and resolution succeeds at min after the bump.

---

Please ignore until reviewed by @ChrisRackauckas.