### PR TITLE
Release prep: batched version bumps for 4 packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.3.3"
+version = "4.3.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
@@ -1,6 +1,6 @@
 name = "RecursiveArrayToolsArrayPartitionAnyAll"
 uuid = "172d604e-c495-4f00-97bf-d70957099afa"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -1,6 +1,6 @@
 name = "RecursiveArrayToolsRaggedArrays"
 uuid = "c384ba91-639a-44ca-823a-e1d3691ab84a"
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
@@ -1,6 +1,6 @@
 name = "RecursiveArrayToolsShorthandConstructors"
 uuid = "39fb7555-b4ad-4efd-8abe-30331df017d3"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"


### PR DESCRIPTION
## Summary

Batched routine-release version bumps for the 4 packages in this monorepo that have unreleased changes on `master` relative to their last registered General version. All classified SAFE (no new public API, no behavior changes to review).

| Package | Old | New | Reason |
|---|---|---|---|
| RecursiveArrayTools (root) | 4.3.3 | 4.3.4 | Own change: CI-only — `.github/workflows/TagBot.yml` updated to targeted monorepo TagBot dispatch (#629). No source changes since 4.3.3. |
| RecursiveArrayToolsArrayPartitionAnyAll | 1.0.1 | 1.0.2 | Own change: QA/test scaffolding converted to SciMLTesting `run_qa` v1.6 form (#621). No `src/` changes. |
| RecursiveArrayToolsRaggedArrays | 1.1.1 | 1.1.2 | Own change: QA/test scaffolding conversion (#621) plus removal of a stale, unused `AllObserved` import from `src/RecursiveArrayToolsRaggedArrays.jl` (mechanical ExplicitImports cleanup — verified the symbol has zero other uses in the file). |
| RecursiveArrayToolsShorthandConstructors | 1.0.1 | 1.0.2 | Own change: QA/test scaffolding converted to SciMLTesting `run_qa` v1.6 form (#621). No `src/` changes. |

## Compat floor cascade check

Dependency graph: `ArrayPartitionAnyAll`, `RaggedArrays`, and `ShorthandConstructors` each depend on root `RecursiveArrayTools` (compat `"4"`); root has a test-only dependency on `ShorthandConstructors` (compat `"1"`). No lib package depends on another lib package.

None of the four bumps introduce new public API or behavior changes, so no sibling's compat floor needed raising — existing `RecursiveArrayTools = "4"` and `RecursiveArrayToolsShorthandConstructors = "1"` floors already resolve correctly against the new patch versions. This PR touches only the four `version` fields; no `[compat]` sections were changed.

## Test plan

- [x] Diffed each package's own subdirectory against the commit corresponding to its last registered version (tree-sha1 confirmed against `JuliaRegistries/General` `Versions.toml` entries) to scope changes precisely.
- [x] Confirmed the `AllObserved` import removed from RaggedArrays has no remaining uses in that file.
- [x] Confirmed root's only non-`lib/` change since 4.3.3 is the CI workflow file.
- [ ] CI on this PR (all packages' test matrices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)