### PR TITLE
Allow SciMLTesting v2 in nested QA envs

### DIFF
--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/Project.toml
@@ -12,6 +12,6 @@ RecursiveArrayToolsArrayPartitionAnyAll = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayToolsArrayPartitionAnyAll = "1"
-SciMLTesting = "1.6"
+SciMLTesting = "1.6, 2.1"
 Test = "1"
 julia = "1.10"

--- a/lib/RecursiveArrayToolsRaggedArrays/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/qa/Project.toml
@@ -12,6 +12,6 @@ RecursiveArrayToolsRaggedArrays = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayToolsRaggedArrays = "1"
-SciMLTesting = "1.6"
+SciMLTesting = "1.6, 2.1"
 Test = "1"
 julia = "1.10"

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/qa/Project.toml
@@ -12,6 +12,6 @@ RecursiveArrayToolsShorthandConstructors = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayToolsShorthandConstructors = "1"
-SciMLTesting = "1.6"
+SciMLTesting = "1.6, 2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Allows `SciMLTesting` v2 in the three nested subpackage QA environments.
- Leaves the root package and existing QA setup unchanged.

## Verification

- `git diff --check`
- `julia --project=. -e 'using Pkg; ... Pkg.TOML.parsefile(...) ...'` confirmed all three touched files have `SciMLTesting = "1.6, 2.1"`.
- `julia --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check <three touched Project.toml files>`
- `julia --project=lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa -e 'using Pkg; Pkg.Registry.add("General"); Pkg.resolve(); Pkg.status(["SciMLTesting"])'` selected `SciMLTesting v2.2.0`.
- `julia --project=lib/RecursiveArrayToolsRaggedArrays/test/qa -e 'using Pkg; Pkg.Registry.add("General"); Pkg.resolve(); Pkg.status(["SciMLTesting"])'` selected `SciMLTesting v2.2.0`.
- `julia --project=lib/RecursiveArrayToolsShorthandConstructors/test/qa -e 'using Pkg; Pkg.Registry.add("General"); Pkg.resolve(); Pkg.status(["SciMLTesting"])'` selected `SciMLTesting v2.2.0`.
- `julia --project=lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/qa.jl` passed: `19` passed.
- `julia --project=lib/RecursiveArrayToolsRaggedArrays/test/qa lib/RecursiveArrayToolsRaggedArrays/test/qa/qa.jl` passed with existing expected broken tests: `17` passed, `2` broken.
- `julia --project=lib/RecursiveArrayToolsShorthandConstructors/test/qa lib/RecursiveArrayToolsShorthandConstructors/test/qa/qa.jl` passed: `19` passed.
