### PR TITLE
Test LabelledArrays Core downstream group

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -25,7 +25,7 @@ jobs:
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core4}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core5}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core6}
-          - {user: SciML, repo: LabelledArrays.jl, group: RecursiveArrayTools}
+          - {user: SciML, repo: LabelledArrays.jl, group: Core}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Run LabelledArrays' current `Core` downstream group from RecursiveArrayTools CI.
- Replace the removed `RecursiveArrayTools` group name without changing any test assertions or disabling coverage.

## Root cause

[RecursiveArrayTools Integration run 29242261727](https://github.com/SciML/RecursiveArrayTools.jl/actions/runs/29242261727) failed in `LabelledArrays.jl/RecursiveArrayTools`. LabelledArrays commit `9f7eaefb524b` migrated its suite to SciMLTesting folder mode and folded `test/recursivearraytools.jl` into the top-level `Core` group. Folder mode now rejects the obsolete group before any tests run.

## Process

This was found while auditing registered SciML packages for downstream CI entries that no longer execute their intended tests. I inspected the failed default-branch job and LabelledArrays group history, reproduced the failure from clean current default branches, changed only the affected matrix cell, and reran the exact downstream target with the current RecursiveArrayTools checkout developed into it.

## Local verification

- Failure reproduction on Julia 1.12.6:
  `JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=RecursiveArrayTools /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  exited 1 with `GROUP="RecursiveArrayTools" ... is not a group declared in test_groups.toml (declared: ["AllocCheck", "Core", "QA"])`.
- Fixed downstream invocation:
  `JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=Core /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  exited 0. It explicitly ran `Core/recursivearraytools.jl | 1 pass / 1 total`, and ended with `Testing LabelledArrays tests passed`.
- Runic 1.7.0 whole-repository check:
  `/home/crackauc/.juliaup/bin/julia +1.12 --project=../runic-env -e 'using Runic; exit(Runic.main(["--check", "--diff", "."]))'`
  exited 0.
- `actionlint .github/workflows/Downstream.yml` exited 0.
- `git diff --check` exited 0.
