### PR TITLE
Drop RecursiveArrayTools nested QA v1 compat

### DIFF
--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/qa/Project.toml
@@ -12,6 +12,6 @@ RecursiveArrayToolsArrayPartitionAnyAll = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayToolsArrayPartitionAnyAll = "1"
-SciMLTesting = "1.6, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/lib/RecursiveArrayToolsRaggedArrays/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/qa/Project.toml
@@ -12,6 +12,6 @@ RecursiveArrayToolsRaggedArrays = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayToolsRaggedArrays = "1"
-SciMLTesting = "1.6, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/qa/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/qa/Project.toml
@@ -12,6 +12,6 @@ RecursiveArrayToolsShorthandConstructors = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayToolsShorthandConstructors = "1"
-SciMLTesting = "1.6, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Drop the remaining `SciMLTesting = "1.6, 2.1"` compat entries from the nested QA environments.
- Leave the QA environments on `SciMLTesting = "2.1"`, which resolves to current v2.x.

## Validation

- `git diff --check`
- `julia +1.10 -e 'using Runic; exit(Runic.main(ARGS))' -- --check .`\n- TOML audit: all `SciMLTesting` compats are v2-only\n- `RECURSIVEARRAYTOOLS_TEST_GROUP=QA julia +1.10 --project=lib/RecursiveArrayToolsArrayPartitionAnyAll -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`\n- `RECURSIVEARRAYTOOLS_TEST_GROUP=QA julia +1.10 --project=lib/RecursiveArrayToolsRaggedArrays -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`\n- `RECURSIVEARRAYTOOLS_TEST_GROUP=QA julia +1.10 --project=lib/RecursiveArrayToolsShorthandConstructors -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`\n\nNotes: the nested QA runs resolved `SciMLTesting v2.2.0` under the `"2.1"` compat. The RaggedArrays QA still reports the existing 2 broken tests while passing the suite.