### PR TITLE
Target downstream tests in the OrdinaryDiffEq monorepo

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -25,7 +25,7 @@ jobs:
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core4}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core5}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core6}
-          - {user: SciML, repo: LabelledArrays.jl, group: RecursiveArrayTools}
+          - {user: SciML, repo: LabelledArrays.jl, group: Core}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -13,12 +13,11 @@ jobs:
       matrix:
         package:
           - {user: SciML, repo: SciMLBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream2}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Core}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
-          - {user: SciML, repo: DelayDiffEq.jl, group: Interface}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Downstream}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Downstream2}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: "", group: Interface}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DelayDiffEq, group: Interface}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core1}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core2}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core3}
@@ -30,6 +29,7 @@ jobs:
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
       julia-version: "1"
     secrets: "inherit"


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- replace the archived standalone DiffEqBase and DelayDiffEq targets with their current OrdinaryDiffEq monorepo subdirectories
- keep OrdinaryDiffEq's root Interface job, while removing the stale duplicate root Core row
- forward the matrix subdirectory to the reusable downstream workflow

This branch includes the LabelledArrays group correction already proposed in #632. Merge #632 first; until then GitHub will show that prerequisite line in this stacked diff.

Depends on:
- SciML/.github#115 for reusable-workflow `subdir` support
- SciML/OrdinaryDiffEq.jl#3909 so migrated sublibrary runners honor the reusable workflow's generic `GROUP`

## Local verification

- `actionlint .github/workflows/Downstream.yml`: passed
- `julia +1.12 -m Runic --check .`: passed
- `git diff --check`: passed
- exact `DelayDiffEq` Interface target: package tests passed; representative summaries include AD 15 pass/6 broken, Backwards 16/16, Composite Solution 12/12, History Function 81/81, and Multi-Algorithm 28/28
- exact `DiffEqBase` Downstream2 target: ran substantive tests (`Prob Kwargs` 3/3, `Unwrapping` 3/3, `DE stats` 4/4) before reaching the independently reproduced obsolete `VectorContinuousCallback` call in `community_callback_tests.jl:230`; that clean-base failure is being fixed separately
- generic-group DelayDiffEq Interface verification against the OrdinaryDiffEq fallback change: package tests passed

The target/group audit classifies every row in the proposed matrix as a real selected group; none falls back silently.