### PR TITLE
Fix recursivecopy for VectorOfArray with immutable outer storage

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,9 +34,23 @@ function recursivecopy(a::AbstractArray{T, N}) where {T <: AbstractArray, N}
 end
 
 function recursivecopy(a::AbstractVectorOfArray)
-    b = copy(a)
-    b.u .= recursivecopy.(a.u)
-    return b
+    # Deep-copy the inner arrays. When the outer container is immutable
+    # (e.g. `SVector` of arrays, OrdinaryDiffEq.jl#1365), broadcast assignment
+    # into `b.u` fails, so rebuild via `rewrap` the way `zero` does.
+    u_copy = map(recursivecopy, a.u)
+    if ArrayInterface.ismutable(a.u)
+        b = copy(a)
+        b.u .= u_copy
+        return b
+    else
+        T = typeof(a)
+        u_rewrapped = rewrap(a.u, u_copy)
+        fields = [
+            fname === :u ? u_rewrapped : _copyfield(a, fname)
+                for fname in fieldnames(T)
+        ]
+        return T(fields...)
+    end
 end
 
 """

--- a/test/Core/utils_test.jl
+++ b/test/Core/utils_test.jl
@@ -152,6 +152,26 @@ end
     @test a.u[1][1] == 1.0
 end
 
+# OrdinaryDiffEq.jl#1365: recursivecopy must not broadcast-assign into an
+# immutable outer container such as SVector of arrays.
+@testset "recursivecopy VectorOfArray with SVector outer (ODE#1365)" begin
+    a = VectorOfArray(SVector{2}([randn(5), randn(5)]))
+    b = recursivecopy(a)
+    @test typeof(b) === typeof(a)
+    @test typeof(b.u) === typeof(a.u)
+    @test b.u == a.u
+    @test !(b.u[1] === a.u[1])
+    @test !(b.u[2] === a.u[2])
+    b.u[1][1] = 999.0
+    @test a.u[1][1] != 999.0
+
+    # mutable outer path still deep-copies
+    c = VectorOfArray([randn(5), randn(5)])
+    d = recursivecopy(c)
+    @test typeof(d.u) === typeof(c.u)
+    @test !(d.u[1] === c.u[1])
+end
+
 @testset "recursivecopyto!" begin
     # Same-shape scalar arrays — should match copyto!
     b = zeros(3)


### PR DESCRIPTION
## Summary

`recursivecopy(::AbstractVectorOfArray)` previously did `b.u .= recursivecopy.(a.u)`. That fails when the outer container is immutable (e.g. `SVector` of arrays) because `setindex!` is undefined on `SVector`.

When the outer storage is immutable, rebuild via `rewrap` (same pattern as `Base.zero`), so the deep copy preserves the outer type and does not share inner arrays.

This is the remaining failure for [OrdinaryDiffEq.jl#1365](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1365) after `zero.(Q)` already preserved `SVector` outer storage.

## Test plan

- [x] Unit test: `recursivecopy(VectorOfArray(SVector{2}([randn(5), randn(5)])))` preserves type, deep-copies inners
- [x] Unit test: mutable outer `Vector` path still deep-copies
- [x] Local minimal repro PASS
- [ ] CI Core / utils tests

This PR should be ignored until reviewed by @ChrisRackauckas.