### PR TITLE
Bump RecursiveArrayTools to v4.3.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.3.5"
+version = "4.3.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Patch bump to release the `recursivecopy` fix from https://github.com/SciML/RecursiveArrayTools.jl/pull/636, which is currently merged to master but unregistered. That fix is the last blocker for https://github.com/SciML/OrdinaryDiffEq.jl/issues/1365 — verified locally on Julia 1.11.9 with `OrdinaryDiffEq` v7.2.1:

- master (`4.3.5` + PR #636): the issue's MWE solves, `sol.retcode == Success`, outer storage preserved as `VectorOfArray{Float64, 2, SVector{2, Vector{Float64}}}`, max error vs the analytic solution `7.7e-12` at `abstol = reltol = 1e-10`
- registered v4.3.5: still fails in `recursivecopy` at `src/utils.jl:38` with `setindex!(::SVector{2, Vector{Float64}}, ...) is not defined`

Bugfix only, no public API change, so a patch bump.

Depends on nothing, but https://github.com/SciML/RecursiveArrayTools.jl/pull/637 (downstream regression test for the same issue) is worth merging first so the release ships with coverage.

## Links

- https://github.com/SciML/OrdinaryDiffEq.jl/issues/1365
- https://github.com/SciML/RecursiveArrayTools.jl/pull/636
- https://github.com/SciML/RecursiveArrayTools.jl/pull/637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DPqBz4Qyy7bZzXZ3sjF45