### PR TITLE
Fix strict QA follow-ups after #640

### DIFF
--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
@@ -5,9 +5,6 @@ version = "1.0.2"
 [deps]
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-
 [compat]
 Pkg = "1"
 RecursiveArrayTools = "4"

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/runtests.jl
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/test/runtests.jl
@@ -1,5 +1,7 @@
-using RecursiveArrayTools, RecursiveArrayToolsArrayPartitionAnyAll, Test
 using Pkg
+Pkg.develop(PackageSpec(path = normpath(joinpath(@__DIR__, "..", "..", ".."))))
+
+using RecursiveArrayTools, RecursiveArrayToolsArrayPartitionAnyAll, Test
 
 const TEST_GROUP = get(ENV, "RECURSIVEARRAYTOOLS_TEST_GROUP", "Core")
 

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -10,9 +10,6 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-
 [compat]
 Adapt = "4"
 ArrayInterface = "7.17.0"

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -20,6 +20,7 @@ LinearAlgebra = "1.10"
 Pkg = "1"
 RecursiveArrayTools = "4"
 SparseArrays = "1.10"
+StaticArrays = "1.6"
 StaticArraysCore = "1.4.2"
 SymbolicIndexingInterface = "0.3.42"
 Test = "1"
@@ -28,8 +29,9 @@ julia = "1.10"
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "SparseArrays", "SymbolicIndexingInterface", "Test"]
+test = ["Pkg", "SparseArrays", "StaticArrays", "SymbolicIndexingInterface", "Test"]

--- a/lib/RecursiveArrayToolsRaggedArrays/src/RecursiveArrayToolsRaggedArrays.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/src/RecursiveArrayToolsRaggedArrays.jl
@@ -1322,7 +1322,7 @@ function Base.copyto!(
         if ArrayInterface.ismutable(dest.u[i]) || dest.u[i] isa AbstractRaggedVectorOfArray
             copyto!(dest.u[i], src.u[j])
         else
-            dest.u[i] = StaticArraysCore.similar_type(dest.u[i])(src.u[j])
+            dest.u[i] = typeof(dest.u[i])(src.u[j])
         end
     end
     return
@@ -1334,7 +1334,7 @@ function Base.copyto!(
         if ArrayInterface.ismutable(dest.u[i]) || dest.u[i] isa AbstractRaggedVectorOfArray
             copyto!(dest.u[i], slice)
         else
-            dest.u[i] = StaticArraysCore.similar_type(dest.u[i])(slice)
+            dest.u[i] = typeof(dest.u[i])(slice)
         end
     end
     return dest
@@ -1455,7 +1455,7 @@ function Base.fill!(VA::AbstractRaggedVectorOfArray, x)
                 fill!(VA[:, i], x)
             else
                 # For immutable arrays like SVector, create a new filled array
-                VA.u[i] = fill(x, StaticArraysCore.similar_type(VA.u[i]))
+                VA.u[i] = typeof(VA.u[i])(fill(x, size(VA.u[i])))
             end
         else
             VA[:, i] = x
@@ -1623,7 +1623,7 @@ for (type, N_expr) in [
                     copyto!(dest[:, i], unpack_voa(bc, i))
                 else
                     unpacked = unpack_voa(bc, i)
-                    arr_type = StaticArraysCore.similar_type(dest[:, i])
+                    arr_type = typeof(dest[:, i])
                     dest[:, i] = if length(unpacked) == 1 && length(dest[:, i]) == 1
                         arr_type(unpacked[1])
                     elseif length(unpacked) == 1

--- a/lib/RecursiveArrayToolsRaggedArrays/test/qa/qa.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/qa/qa.jl
@@ -15,15 +15,6 @@ run_qa(
         ),
     ),
     jet_kwargs = (; target_modules = (RecursiveArrayToolsRaggedArrays,)),
-    # Pre-existing JET typo-mode finding (reproduces byte-identically on master):
-    # the `copyto!`/`fill!`/broadcast immutable-element branches call
-    # `StaticArraysCore.similar_type(dest.u[i])`, but `dest.u[i]` infers as `::Any`
-    # because the abstract `AbstractRaggedVectorOfArray` `.u` field is untyped, so
-    # `similar_type(::Any)` has no matching method. Tracked (with the real fix —
-    # tightening the `.u` type / guarding the immutable branch) in
-    # https://github.com/SciML/RecursiveArrayTools.jl/issues/620. JET 0.9 on Julia
-    # 1.10 does not report this finding, so keep that stricter lane unbroken.
-    jet_broken = VERSION >= v"1.11",
     ei_kwargs = (;
         # Non-public names legitimately qualified/imported from upstream packages
         # (Base, Base.Broadcast, StaticArraysCore, ArrayInterface, Adapt,
@@ -35,7 +26,7 @@ run_qa(
                 :Slice, :SolvedVariables, :StaticVecOrMat, :SymbolicTypeTrait,
                 :adapt_structure, :add_sum, :broadcastable, :check_parent_index_match,
                 :ensure_indexable, :flatten, :front, :index_dimsum, :ismutable,
-                :issingular, :maybeview, :mul_prod, :similar_type, :tail, :typename,
+                :issingular, :maybeview, :mul_prod, :tail, :typename,
                 :unalias, :viewindexing,
             ),
         ),

--- a/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
@@ -1,10 +1,12 @@
+using Pkg
+Pkg.develop(PackageSpec(path = normpath(joinpath(@__DIR__, "..", "..", ".."))))
+
 using RecursiveArrayTools, RecursiveArrayToolsRaggedArrays
 using RecursiveArrayToolsRaggedArrays: RaggedEnd, RaggedRange
 using SymbolicIndexingInterface
 using SymbolicIndexingInterface: SymbolCache
 using StaticArrays
 using Test
-using Pkg
 
 const TEST_GROUP = get(ENV, "RECURSIVEARRAYTOOLS_TEST_GROUP", "Core")
 

--- a/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
@@ -2,6 +2,7 @@ using RecursiveArrayTools, RecursiveArrayToolsRaggedArrays
 using RecursiveArrayToolsRaggedArrays: RaggedEnd, RaggedRange
 using SymbolicIndexingInterface
 using SymbolicIndexingInterface: SymbolCache
+using StaticArrays
 using Test
 using Pkg
 
@@ -25,6 +26,24 @@ end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @testset "RecursiveArrayToolsRaggedArrays" begin
+        @testset "immutable inner arrays" begin
+            src = RaggedVectorOfArray([SVector(1, 2), SVector(3, 4)])
+            dest = RaggedVectorOfArray([SVector(0, 0), SVector(0, 0)])
+
+            copyto!(dest, src)
+            @test dest.u == src.u
+            @test eltype(dest.u) === SVector{2, Int}
+
+            copyto!(dest, [5 7; 6 8])
+            @test dest.u == [SVector(5, 6), SVector(7, 8)]
+
+            fill!(dest, 9)
+            @test dest.u == [SVector(9, 9), SVector(9, 9)]
+
+            dest .= src .+ 1
+            @test dest.u == [SVector(2, 3), SVector(4, 5)]
+        end
+
         # ===================================================================
         # Tests ported from v3 basic_indexing.jl
         # ===================================================================

--- a/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
@@ -5,9 +5,6 @@ version = "1.0.2"
 [deps]
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-
 [compat]
 Pkg = "1"
 RecursiveArrayTools = "4"

--- a/lib/RecursiveArrayToolsShorthandConstructors/test/runtests.jl
+++ b/lib/RecursiveArrayToolsShorthandConstructors/test/runtests.jl
@@ -1,5 +1,7 @@
-using RecursiveArrayTools, RecursiveArrayToolsShorthandConstructors, Test
 using Pkg
+Pkg.develop(PackageSpec(path = normpath(joinpath(@__DIR__, "..", "..", ".."))))
+
+using RecursiveArrayTools, RecursiveArrayToolsShorthandConstructors, Test
 
 const TEST_GROUP = get(ENV, "RECURSIVEARRAYTOOLS_TEST_GROUP", "Core")
 

--- a/test/AD/Project.toml
+++ b/test/AD/Project.toml
@@ -6,9 +6,6 @@ ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-
 [compat]
 ForwardDiff = "0.10.38, 1"
 Mooncake = "0.5"

--- a/test/Downstream/Project.toml
+++ b/test/Downstream/Project.toml
@@ -15,10 +15,6 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-RecursiveArrayToolsShorthandConstructors = {path = "../../lib/RecursiveArrayToolsShorthandConstructors"}
-
 [compat]
 ArrayInterface = "7"
 ModelingToolkit = "8.33, 9, 10, 11"

--- a/test/GPU/Project.toml
+++ b/test/GPU/Project.toml
@@ -8,10 +8,6 @@ RecursiveArrayToolsArrayPartitionAnyAll = "172d604e-c495-4f00-97bf-d70957099afa"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-RecursiveArrayToolsArrayPartitionAnyAll = {path = "../../lib/RecursiveArrayToolsArrayPartitionAnyAll"}
-
 [compat]
 Adapt = "4"
 ArrayInterface = "7.17.0"

--- a/test/NoPre/Project.toml
+++ b/test/NoPre/Project.toml
@@ -3,9 +3,6 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-RecursiveArrayTools = {path = "../.."}
-
 [compat]
 JET = "0.9, 0.10, 0.11"
 RecursiveArrayTools = "4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,12 +36,20 @@ run_tests(;
         # second half of both the "SymbolicIndexingInterface" and "Downstream" paths.
         "SII_Downstream" => (;
             env = joinpath(@__DIR__, "Downstream"),
+            parent = [
+                dirname(@__DIR__),
+                joinpath(dirname(@__DIR__), "lib", "RecursiveArrayToolsShorthandConstructors"),
+            ],
             body = function ()
                 return @time @safetestset "DiffEqArray Indexing Tests" include("Downstream/symbol_indexing.jl")
             end,
         ),
         "Downstream" => (;
             env = joinpath(@__DIR__, "Downstream"),
+            parent = [
+                dirname(@__DIR__),
+                joinpath(dirname(@__DIR__), "lib", "RecursiveArrayToolsShorthandConstructors"),
+            ],
             body = function ()
                 @time @safetestset "ODE Solve Tests" include("Downstream/odesolve.jl")
                 @time @safetestset "Event Tests with ArrayPartition" include("Downstream/downstream_events.jl")
@@ -65,6 +73,7 @@ run_tests(;
         ),
         "NoPre" => (;
             env = joinpath(@__DIR__, "NoPre"),
+            parent = dirname(@__DIR__),
             body = function ()
                 return @time @safetestset "JET Tests" include("NoPre/jet_tests.jl")
             end,
@@ -76,6 +85,7 @@ run_tests(;
         # cannot satisfy when it minimizes Julia to the 1.10.0 LTS floor.
         "AD" => (;
             env = joinpath(@__DIR__, "AD"),
+            parent = dirname(@__DIR__),
             body = function ()
                 @time @safetestset "Adjoint Tests" include("AD/adjoints.jl")
                 return @time @safetestset "Mooncake Tests" include("AD/mooncake.jl")


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- fix RaggedArrays inference when the ragged element storage is immutable
- add a StaticArrays regression test for immutable storage
- remove persistent local `[sources]` path overrides from monorepo test environments
- develop the checked-out root and subpackages at test runtime instead

The pre-existing root-package ambiguity exception remains narrowly scoped. The underlying ambiguity families and their introducing commits are recorded in #326; this PR does not hide any new QA failure.

## Local verification
- Julia release root Core passed
- Julia release root QA passed: 19 passed, 1 pre-existing broken
- Julia 1.10 root Core passed
- Julia 1.10 root QA passed: 17 passed, 1 pre-existing broken
- Julia release and 1.10 Core/QA passed for RecursiveArrayToolsArrayPartitionAnyAll
- Julia release and 1.10 Core/QA passed for RecursiveArrayToolsRaggedArrays
- Julia release and 1.10 Core/QA passed for RecursiveArrayToolsShorthandConstructors
- Runic 1.7 check passed on all changed Julia files
- `git diff --check` passed

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>