### PR TITLE
Set sequential release versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecursiveArrayTools"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.3.6"
+version = "4.3.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -1,6 +1,6 @@
 name = "RecursiveArrayToolsRaggedArrays"
 uuid = "c384ba91-639a-44ca-823a-e1d3691ab84a"
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| RecursiveArrayTools | 4.3.6 | 4.3.6 | 4.3.7 | patch |
| RecursiveArrayToolsRaggedArrays | 1.1.2 | 1.1.2 | 1.1.3 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Broken  Total   Time / QA            |   19       1     20  32.1s / Testing RecursiveArrayTools tests passed`
- `GROUP=RecursiveArrayToolsRaggedArrays /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:                   | Pass  Broken  Total   Time / RecursiveArrayToolsRaggedArrays |  440       2    442  57.0s / Testing RecursiveArrayTools tests passed`
- `GROUP=RecursiveArrayToolsRaggedArrays_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Broken  Total   Time / Quality Assurance |   20       1     21  52.4s / Testing RecursiveArrayTools tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total  Time / Measurement Tests |    2      2  0.1s / Test Summary:                      | Pass  Total  Time / SymbolicIndexingInterface API test |   36     36  7.4s / Testing RecursiveArrayTools tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml lib/RecursiveArrayToolsRaggedArrays/Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- RecursiveArrayTools: `@JuliaRegistrator register`
- RecursiveArrayToolsRaggedArrays: `@JuliaRegistrator register subdir=lib/RecursiveArrayToolsRaggedArrays`