### PR TITLE
docs: document RecursiveArrayTools interfaces

### DIFF
--- a/docs/src/AbstractVectorOfArrayInterface.md
+++ b/docs/src/AbstractVectorOfArrayInterface.md
@@ -1,5 +1,25 @@
 # The AbstractVectorOfArray and AbstractDiffEqArray Interfaces
 
+`AbstractVectorOfArray` is an extension point for array containers that store a
+collection of inner arrays. A concrete subtype must also satisfy the relevant
+`AbstractArray` interface: provide `size`, `getindex`, and `setindex!` when the
+storage is mutable, and use an indexable `u` field for the inner arrays. The last
+index selects an entry of `u`; `A[:, j]` must agree with `A.u[j]` for vector-valued
+inner arrays. Rectangular implementations may expose the ordinary array shape,
+while ragged input uses the maximum shape with zero values outside each inner
+array's stored bounds.
+
+Generic operations such as `Array(A)`, `recursivecopy!`, `recursivecopyto!`,
+`recursivefill!`, and `vecarr_to_vectors` rely only on that contract. Code that
+needs the stored inner arrays directly should use `A.u`, not iteration over `A`:
+iteration follows the scalar `AbstractArray` interface.
+
+`AbstractDiffEqArray` adds aligned `t`, `p`, and `sys` metadata to the same
+contract. A concrete subtype must keep `length(A.t) == length(A.u)` under mutation.
+When `A.interp !== nothing`, calling `A(t; idxs = ..., continuity = ...)` forwards
+to `A.interp(t, idxs, deriv, A.p, continuity)`; otherwise the call reports that
+interpolation data is unavailable.
+
 ```@docs
 AbstractVectorOfArray
 AbstractDiffEqArray

--- a/docs/src/ragged_arrays.md
+++ b/docs/src/ragged_arrays.md
@@ -184,6 +184,14 @@ structure and access elements without implicit zeros.
 The abstract types below are developer interfaces for packages implementing ragged containers.
 Application code should construct `RaggedVectorOfArray` or `RaggedDiffEqArray`.
 
+A concrete `AbstractRaggedVectorOfArray` must expose an indexable `u` field and preserve
+the true shape of every inner array. It must support the ragged indexing contract,
+including `A[:, j] == A.u[j]`, and may use the generic conversion, copying, filling,
+iteration, and broadcasting methods supplied by the subpackage. It must not claim the
+rectangular `AbstractArray` interface or add implicit zero padding. A concrete
+`AbstractRaggedDiffEqArray` follows the same rules and additionally keeps `t`, `p`, and
+`sys` metadata aligned with `u`.
+
 ```@docs
 RecursiveArrayTools.AbstractRaggedVectorOfArray
 RecursiveArrayTools.AbstractRaggedDiffEqArray

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
@@ -12,7 +12,7 @@ RecursiveArrayTools = {path = "../.."}
 Pkg = "1"
 RecursiveArrayTools = "4"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
+++ b/lib/RecursiveArrayToolsArrayPartitionAnyAll/Project.toml
@@ -12,9 +12,11 @@ RecursiveArrayTools = {path = "../.."}
 Pkg = "1"
 RecursiveArrayTools = "4"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -23,7 +23,7 @@ SparseArrays = "1.10"
 StaticArraysCore = "1.4.2"
 SymbolicIndexingInterface = "0.3.42"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/RecursiveArrayToolsRaggedArrays/Project.toml
+++ b/lib/RecursiveArrayToolsRaggedArrays/Project.toml
@@ -23,9 +23,11 @@ SparseArrays = "1.10"
 StaticArraysCore = "1.4.2"
 SymbolicIndexingInterface = "0.3.42"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"

--- a/lib/RecursiveArrayToolsRaggedArrays/src/RecursiveArrayToolsRaggedArrays.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/src/RecursiveArrayToolsRaggedArrays.jl
@@ -24,6 +24,16 @@ export RaggedVectorOfArray, RaggedDiffEqArray
 Wrap a collection of arrays while preserving each array's shape. Unlike `VectorOfArray`,
 this type does not present zero-padded ragged data as a rectangular `AbstractArray`.
 
+# Arguments
+
+- `u`: an indexable collection of inner arrays. Each inner array keeps its own shape.
+
+# Returns
+
+A mutable `RaggedVectorOfArray` implementing the ragged indexing and broadcasting
+interface. It does not subtype `AbstractArray` because its columns may have different
+sizes.
+
 # Fields
 
 - `u`: the collection of stored arrays.
@@ -46,6 +56,24 @@ end
 
 Wrap ragged saved states `u` and matching time points `t` with differential-equation and
 symbolic-indexing metadata.
+
+# Arguments
+
+- `u`: an indexable collection of saved ragged state arrays.
+- `t`: the time values corresponding to the entries of `u`.
+
+# Keyword Arguments
+
+- `discretes`: discrete parameter timeseries, or `nothing`.
+- `variables`: variable symbols for symbolic-indexing metadata.
+- `parameters`: parameter symbols for symbolic-indexing metadata.
+- `independent_variables`: independent-variable symbols for symbolic-indexing metadata.
+- `interp`: an interpolation object, or `nothing`.
+- `dense`: whether dense interpolation is available.
+
+# Returns
+
+A mutable `RaggedDiffEqArray` with time, parameter, and symbolic-indexing metadata.
 
 # Fields
 

--- a/lib/RecursiveArrayToolsRaggedArrays/test/interface_tests.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/interface_tests.jl
@@ -1,0 +1,54 @@
+using RecursiveArrayTools
+using RecursiveArrayToolsRaggedArrays
+using SymbolicIndexingInterface
+using Test
+
+struct GenericRaggedVectorOfArray{T, N, A} <:
+    RecursiveArrayTools.AbstractRaggedVectorOfArray{T, N, A}
+    u::A
+end
+
+GenericRaggedVectorOfArray(u::A) where {A <: AbstractVector} =
+    GenericRaggedVectorOfArray{eltype(eltype(u)), 2, A}(u)
+
+struct GenericRaggedDiffEqArray{T, A} <:
+    RecursiveArrayTools.AbstractRaggedDiffEqArray{T, 2, A}
+    u::A
+    t::Vector{Float64}
+    p
+    sys
+    discretes
+    interp
+    dense::Bool
+end
+
+@testset "Generic AbstractRaggedVectorOfArray interface" begin
+    source = GenericRaggedVectorOfArray([[1, 2], [3, 4]])
+    destination = GenericRaggedVectorOfArray([[0, 0], [0, 0]])
+    ragged = GenericRaggedVectorOfArray([[1, 2], [3, 4, 5]])
+
+    @test size(source) == (2, 2)
+    @test source[:, 1] == [1, 2]
+    @test source[2, 2] == 4
+    @test Array(source) == [1 3; 2 4]
+    @test RecursiveArrayToolsRaggedArrays.narrays(source) == 2
+    @test ragged[3, 2] == 5
+    @test_throws DimensionMismatch Array(ragged)
+
+    recursivecopy!(destination, source)
+    @test destination.u == source.u
+    recursivefill!(destination, 0)
+    @test destination.u == [[0, 0], [0, 0]]
+end
+
+@testset "Generic AbstractRaggedDiffEqArray interface" begin
+    solution = GenericRaggedDiffEqArray{Float64, Vector{Vector{Float64}}}(
+        [[1.0, 2.0], [3.0, 4.0]], [0.0, 1.0], nothing, nothing, nothing, nothing, false
+    )
+
+    @test solution[:, 1] == [1.0, 2.0]
+    @test SymbolicIndexingInterface.state_values(solution) === solution.u
+    @test SymbolicIndexingInterface.current_time(solution) === solution.t
+    @test SymbolicIndexingInterface.parameter_values(solution) === solution.p
+    @test SymbolicIndexingInterface.symbolic_container(solution) === solution.sys
+end

--- a/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
+++ b/lib/RecursiveArrayToolsRaggedArrays/test/runtests.jl
@@ -24,6 +24,8 @@ if TEST_GROUP == "QA"
 end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
+    include("interface_tests.jl")
+
     @testset "RecursiveArrayToolsRaggedArrays" begin
         # ===================================================================
         # Tests ported from v3 basic_indexing.jl

--- a/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
@@ -12,7 +12,7 @@ RecursiveArrayTools = {path = "../.."}
 Pkg = "1"
 RecursiveArrayTools = "4"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
+++ b/lib/RecursiveArrayToolsShorthandConstructors/Project.toml
@@ -12,9 +12,11 @@ RecursiveArrayTools = {path = "../.."}
 Pkg = "1"
 RecursiveArrayTools = "4"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -50,9 +50,17 @@ module RecursiveArrayTools
 
     ## Fields
 
-    An AbstractVectorOfArray has the following fields:
+    Concrete subtypes must expose the following field:
 
-      - `u` which holds the Vector of values at each timestep
+      - `u`, an indexable collection holding the inner arrays. The last index of
+        the array interface selects an entry of `u`.
+
+    Concrete subtypes must also implement `size`, `getindex`, and `setindex!` as
+    appropriate for their storage. They must preserve the column-major convention:
+    `A[I..., j]` indexes `A.u[j]`, and `A[:, j]` returns that inner array (or its
+    rectangular, zero-padded view when the inner arrays are ragged). The generic
+    copying, filling, conversion, and component-series functions in
+    `RecursiveArrayTools` are defined in terms of this contract.
 
     ## Array Interface
 
@@ -132,14 +140,19 @@ module RecursiveArrayTools
 
     ## Fields
 
-    An AbstractDiffEqArray adds the following fields:
+    Concrete subtypes of AbstractDiffEqArray add the following fields:
 
-      - `t` which holds the times of each timestep.
-      - `p` which holds the parameter values.
-      - `sys` which holds the symbolic system (e.g. `SymbolCache`).
-      - `discretes` which holds discrete parameter timeseries.
-      - `interp` which holds an interpolation object for dense output (default `nothing`).
-      - `dense` which indicates whether dense interpolation is available (default `false`).
+      - `t`, the time corresponding to each entry of `u`.
+      - `p`, the parameter values associated with the saved states.
+      - `sys`, symbolic-indexing metadata such as a `SymbolCache`, or `nothing`.
+      - `discretes`, discrete parameter timeseries, or `nothing`.
+      - `interp`, an interpolation object for dense output, or `nothing`.
+      - `dense`, whether dense interpolation is available.
+
+    The lengths of `u` and `t` must stay aligned when the container is resized or
+    otherwise mutated. A subtype with a non-`nothing` `interp` field must accept
+    the callable interface below; otherwise calling it should report that no
+    interpolation data is available.
 
     ## Callable Interface
 
@@ -190,8 +203,12 @@ module RecursiveArrayTools
     # Developer Interface
 
     Subtypes must satisfy the `AbstractRaggedVectorOfArray` contract and expose
-    `t`, `p`, and `sys` metadata compatible with `DiffEqArray`. The metadata must
-    remain aligned with the entries of `u` whenever the container is mutated.
+    `t`, `p`, and `sys` metadata compatible with `DiffEqArray`. They may also
+    expose `discretes`, `interp`, and `dense` fields for discrete parameters and
+    interpolation. The metadata must remain aligned with the entries of `u`
+    whenever the container is mutated. Application code should use the generic
+    symbolic-indexing methods on the subtype rather than inspecting these fields
+    directly.
     Application code should construct `RaggedDiffEqArray` instead of subtyping
     this interface.
     """

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -5,6 +5,22 @@ Wrap arrays with potentially different types as one linear `AbstractVector`. Ind
 traverses the partitions in order, while broadcasting operates partition-by-partition
 without losing the individual array types.
 
+# Arguments
+
+- `parts...`: arrays or scalar values to store as the partitions.
+- `copy_x`: when constructing from a tuple with `Val{true}`, copy each partition;
+  the default `Val{false}` preserves the supplied partition objects.
+
+# Returns
+
+An `ArrayPartition` whose element type is the promoted bottom element type of
+the partitions.
+
+# Errors
+
+`ArrayPartition{T, S}(undef, n)` throws an `ArgumentError` unless `S` describes
+exactly one partition.
+
 # Fields
 
 - `x`: the tuple of stored arrays.

--- a/src/named_array_partition.jl
+++ b/src/named_array_partition.jl
@@ -6,6 +6,25 @@ Similar to an `ArrayPartition` but the individual arrays can be accessed via the
 constructor-specified names. However, unlike `ArrayPartition`, each individual array
 must have the same element type.
 
+# Arguments
+
+- `kwargs...`: named partitions, for example `position = [1.0, 2.0]`.
+- `x`: a `NamedTuple` containing the named partitions.
+
+# Fields
+
+- `array_partition`: the underlying `ArrayPartition`.
+- `names_to_indices`: a `NamedTuple` mapping each constructor name to its partition index.
+
+# Returns
+
+A named linear `AbstractVector` whose properties access the corresponding
+partitions.
+
+# Errors
+
+Construction asserts that all partitions have the same element type.
+
 # Examples
 
 ```julia

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -8,6 +8,23 @@ without materializing a dense concatenation. The last index selects an inner arr
 `A[j, i]` accesses component `j` of `A.u[i]`, while `A.u[i]` returns the stored
 array itself.
 
+# Arguments
+
+- `u`: an indexable collection of inner arrays. The first inner array determines
+  the element type and dimensionality; later arrays may be ragged in size.
+
+# Returns
+
+A mutable `VectorOfArray` with `size(A) == (size(A.u[1])..., length(A.u))` for
+rectangular input. Ragged input is represented by the maximum inner size and
+reads outside an inner array as zero.
+
+# Notes
+
+`VectorOfArray` implements the `AbstractArray` interface. Use `A.u[i]` or
+`A[:, i]` to access an inner array; linear indexing `A[i]` accesses scalar
+elements in column-major order.
+
 # Fields
 
 - `u`: the collection of stored arrays.
@@ -32,6 +49,27 @@ end
 Wrap saved state arrays `u` and matching time points `t` as an `AbstractDiffEqArray`.
 The result supports the `VectorOfArray` interface and stores metadata used for symbolic
 indexing, interpolation, and plotting.
+
+# Arguments
+
+- `u`: an indexable collection of saved state arrays.
+- `t`: the time values corresponding to the entries of `u`.
+
+# Keyword Arguments
+
+- `discretes`: discrete parameter timeseries, or `nothing`.
+- `variables`: variable symbols used to construct symbolic-indexing metadata.
+- `parameters`: parameter symbols used to construct symbolic-indexing metadata.
+- `independent_variables`: independent-variable symbols used to construct
+  symbolic-indexing metadata.
+- `interp`: an interpolation object called as `interp(t, idxs, deriv, p, continuity)`.
+- `dense`: whether dense interpolation is available.
+
+# Returns
+
+A mutable `DiffEqArray` with the saved states, times, parameters, and symbolic
+indexing metadata. Positional overloads additionally accept `p` and `sys` when
+those objects have already been constructed.
 
 # Fields
 

--- a/test/Core/interface_tests.jl
+++ b/test/Core/interface_tests.jl
@@ -4,6 +4,61 @@ using FastBroadcast
 using Polyester
 using SymbolicIndexingInterface: SymbolCache
 
+struct GenericVectorOfArray{T, N, A} <: AbstractVectorOfArray{T, N, A}
+    u::A
+end
+
+GenericVectorOfArray(u::A) where {A <: AbstractVector} =
+    GenericVectorOfArray{eltype(eltype(u)), 2, A}(u)
+
+Base.size(A::GenericVectorOfArray) = (length(A.u[1]), length(A.u))
+Base.getindex(A::GenericVectorOfArray, i::Int, j::Int) = A.u[j][i]
+Base.getindex(A::GenericVectorOfArray, ::Colon, j::Int) = A.u[j]
+Base.getindex(A::GenericVectorOfArray, i::Int, ::Colon) = [u[i] for u in A.u]
+
+struct GenericDiffEqArray{T, A} <: AbstractDiffEqArray{T, 2, A}
+    u::A
+    t::Vector{Float64}
+    p
+    sys
+    discretes
+    interp
+    dense::Bool
+end
+
+Base.size(A::GenericDiffEqArray) = (length(A.u[1]), length(A.u))
+Base.getindex(A::GenericDiffEqArray, i::Int, j::Int) = A.u[j][i]
+Base.getindex(A::GenericDiffEqArray, ::Colon, j::Int) = A.u[j]
+Base.getindex(A::GenericDiffEqArray, i::Int, ::Colon) = [u[i] for u in A.u]
+
+@testset "Generic AbstractVectorOfArray interface" begin
+    source = GenericVectorOfArray([[1, 2], [3, 4]])
+    destination = GenericVectorOfArray([[0, 0], [0, 0]])
+
+    @test Array(source) == [1 3; 2 4]
+    @test vecarr_to_vectors(source) == [[1, 3], [2, 4]]
+    @test sum(source) == 10
+
+    recursivecopy!(destination, source)
+    @test destination.u == source.u
+    recursivefill!(destination, 0)
+    @test destination.u == [[0, 0], [0, 0]]
+    recursivecopyto!(destination, source)
+    @test destination.u == source.u
+end
+
+@testset "Generic AbstractDiffEqArray interface" begin
+    interp = (t, idxs, deriv, p, continuity) -> t
+    solution = GenericDiffEqArray{Float64, Vector{Vector{Float64}}}(
+        [[1.0, 2.0], [3.0, 4.0]], [0.0, 1.0], nothing, nothing, nothing, interp, true
+    )
+
+    @test solution(0.5) == 0.5
+    @test solution(0.5; continuity = :right) == 0.5
+    @test solution[:, 1] == [1.0, 2.0]
+    @test solution[1, :] == [1.0, 3.0]
+end
+
 if isdefined(Base, :ispublic)
     @testset "Ragged developer API declarations" begin
         for name in (:AbstractRaggedVectorOfArray, :AbstractRaggedDiffEqArray)


### PR DESCRIPTION
## Summary

Update the existing SciMLTesting compatibility PR with focused public API documentation and generic interface coverage.

- Keep the affected sublibrary QA environments on SciMLTesting >= 2.4 (the branch currently declares 2.10).
- Add SciMLStyle constructor documentation for ArrayPartition, NamedArrayPartition, VectorOfArray, DiffEqArray, RaggedVectorOfArray, and RaggedDiffEqArray at their original definitions.
- Clarify the root AbstractVectorOfArray/AbstractDiffEqArray contracts and the developer-only ragged interfaces in the API docs.
- Add generic interface tests for the root and ragged abstract interfaces.
- No runtime behavior changes, repo-specific rendered/doctest overrides, or broad test changes.

## Verification

- Julia Runic check passed.
- typos and git diff check passed.
- Root QA passed: 19 passed, 1 pre-existing broken ambiguity test, 20 total; SciMLTesting resolved to v2.10.0.
- Ragged sublibrary Core passed: 440 passed, 2 pre-existing broken tests, 442 total; the new generic interface tests passed 9/9 and 5/5.
- The docs build passed through Doctest, CheckDocument, and HTMLWriter. Deployment was skipped because this was a local build.

Please ignore this draft until reviewed by @ChrisRackauckas.