### PR TITLE
fix: resolve ArrayPartition ambiguity QA

### DIFF
--- a/src/RecursiveArrayTools.jl
+++ b/src/RecursiveArrayTools.jl
@@ -9,8 +9,8 @@ provides array-compatible wrappers such as [`VectorOfArray`](@ref), [`DiffEqArra
 module RecursiveArrayTools
 
     using ArrayInterface: ArrayInterface
-    using LinearAlgebra: LinearAlgebra, Adjoint, Factorization, I, LDLt, LU,
-        LowerTriangular, SymTridiagonal, Transpose, Tridiagonal, UnitLowerTriangular,
+    using LinearAlgebra: LinearAlgebra, Adjoint, I, LU, LowerTriangular, Transpose,
+        Tridiagonal, UnitLowerTriangular,
         UnitUpperTriangular, UpperTriangular, ldiv!, mul!
     using RecipesBase: RecipesBase, @recipe
     using SciMLPublic: @public

--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -268,6 +268,25 @@ function Base.copyto!(A::ArrayPartition, src::ArrayPartition)
     return A
 end
 
+function Base.copyto!(
+        dest::AbstractVectorOfArray{T, 1}, src::ArrayPartition{T2}
+    ) where {T, T2}
+    return copyto!(dest.u, src)
+end
+
+function Base.copyto!(
+        dest::AbstractVectorOfArray{T, 1, <:AbstractVector{T}},
+        src::AbstractVectorOfArray{T2, 1}
+    ) where {T, T2}
+    return copyto!(dest.u, src)
+end
+
+function Base.copyto!(
+        dest::AbstractVectorOfArray{T, N, <:AbstractVector{T}}, src::ArrayPartition
+    ) where {T, N}
+    return copyto!(dest.u, src)
+end
+
 function Base.fill!(A::ArrayPartition, x)
     unrolled_foreach!(A.x) do x_
         fill!(x_, x)
@@ -577,26 +596,17 @@ function ArrayInterface.zeromatrix(A::ArrayPartition)
     return x .* x' .* false
 end
 
-function __get_subtypes_in_module(
-        mod, supertype; include_supertype = true, all = false, except = []
-    )
-    return filter([getproperty(mod, name) for name in names(mod; all) if !in(name, except)]) do value
-        return value != Union{} && value isa Type && (value <: supertype) &&
-            (include_supertype || value != supertype) && !in(value, except)
-    end
+function _ldiv_array_partition!(A, b::ArrayPartition)
+    x = ldiv!(A, Array(b))
+    return copyto!(b, x)
 end
 
-for factorization in vcat(
-        __get_subtypes_in_module(
-            LinearAlgebra, Factorization; include_supertype = false,
-            all = true, except = [:LU, :LAPACKFactorizations]
-        ),
-        LDLt{T, <:SymTridiagonal{T, V} where {V <: AbstractVector{T}}} where {T}
-    )
-    @eval function LinearAlgebra.ldiv!(A::T, b::ArrayPartition) where {T <: $factorization}
-        (x = ldiv!(A, Array(b)); copyto!(b, x))
-    end
-end
+LinearAlgebra.ldiv!(A::LinearAlgebra.QR, b::ArrayPartition) =
+    _ldiv_array_partition!(A, b)
+
+LinearAlgebra.ldiv!(
+    A::LinearAlgebra.SVD{T, Tr, M}, b::ArrayPartition
+) where {T, Tr, M <: AbstractArray{T}} = _ldiv_array_partition!(A, b)
 
 function LinearAlgebra.ldiv!(
         A::LinearAlgebra.QRPivoted{T, <:StridedMatrix{T}, <:AbstractVector{T}},

--- a/test/Core/linalg.jl
+++ b/test/Core/linalg.jl
@@ -29,6 +29,17 @@ for ff in (lu, svd, qr, Base.Fix2(qr, ColumnNorm()))
     @test A * bbb ≈ b
 end
 
+@testset "VectorOfArray copy intersections" begin
+    destination = VectorOfArray([0.0, 0.0])
+    source = ArrayPartition(1.0, 2.0)
+    @test copyto!(destination, source) == source
+    @test destination.u == [1.0, 2.0]
+
+    source_vector_of_array = VectorOfArray([3.0, 4.0])
+    @test copyto!(destination, source_vector_of_array) == source_vector_of_array
+    @test destination.u == [3.0, 4.0]
+end
+
 # linalg mul! overloads
 n, m, l = 5, 6, 7
 bb = rand(n, n), rand(m, n), rand(l, n)

--- a/test/QA/qa.jl
+++ b/test/QA/qa.jl
@@ -9,9 +9,6 @@ end
 
 run_qa(
     RecursiveArrayTools;
-    # Method-table ambiguities tracked in
-    # https://github.com/SciML/RecursiveArrayTools.jl/issues/326
-    aqua_broken = (:ambiguities,),
     ei_kwargs = (;
         # Non-public names legitimately qualified/imported from upstream packages
         # (Base, Base.Broadcast, LinearAlgebra, StaticArraysCore, ArrayInterface,


### PR DESCRIPTION
Removes the broad Aqua ambiguity exemption with source-level method disambiguation. `ArrayPartition` now has explicit intersections for `copyto!` with `AbstractVectorOfArray`, and its generic factorization extension is narrowed to the tested QR/SVD paths instead of discovering and extending every `LinearAlgebra.Factorization` subtype. No exports or reexports change.

Please ignore until reviewed by @ChrisRackauckas.

Verification:

- Before: removing `aqua_broken = (:ambiguities,)` reported 12 ambiguities: three `copyto!` intersections and nine generated `ldiv!` intersections.
- After: `GROUP=QA julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed `20/20`.\n- Focused `test/Core/linalg.jl` passed, including `VectorOfArray copy intersections` (`4/4`). The new calls would dispatch ambiguously before the source definitions.\n- Runic check, `typos`, and `git diff --check` passed.\n\nNot run: the full Core group was started after the test correction but did not produce a completed local summary in this runner session; the focused affected test file is green.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791